### PR TITLE
Fix cross-protocol-cross-domain requests on IE8, IE9

### DIFF
--- a/lib/transports/index.js
+++ b/lib/transports/index.js
@@ -25,14 +25,23 @@ exports.flashsocket = flashsocket;
  */
 
 function polling (opts) {
-  var xd = false;
+  var xhr
+    , xd = false
+    , isXProtocol = false;
 
   if (global.location) {
     xd = opts.host != global.location.hostname
       || global.location.port != opts.port;
+    isXProtocol = (opts.secure !== (global.location.protocol === 'https:'));
   }
 
-  if (util.request(xd) && !opts.forceJSONP) {
+  xhr = util.request(xd);
+  /* See #7 at http://blogs.msdn.com/b/ieinternals/archive/2010/05/13/xdomainrequest-restrictions-limitations-and-workarounds.aspx */
+  if (isXProtocol && global.XDomainRequest && xhr instanceof global.XDomainRequest) {
+    return new JSONP(opts);
+  }
+
+  if (xhr && !opts.forceJSONP) {
     return new XHR(opts);
   } else {
     return new JSONP(opts);


### PR DESCRIPTION
IE's XDomainRequest cannot do requests that go from HTTPS to HTTP or HTTP to HTTPS, so fall back to JSONP.

Similar to https://github.com/LearnBoost/socket.io-client/blob/master/lib/transports/xhr.js#L188
