### PR TITLE
allow path === ""

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -37,7 +37,10 @@ function Socket (opts) {
   this.query.uid = rnd();
   this.upgrade = false !== opts.upgrade;
   this.resource = opts.resource || 'default';
-  this.path = (opts.path || '/engine.io').replace(/\/$/, '');
+  this.path = '/engine.io';
+  if (typeof opts.path === 'string') {
+    this.path = opts.path.replace(/\/$/, '');
+  }
   this.path += '/' + this.resource + '/';
   this.forceJSONP = !!opts.forceJSONP;
   this.timestampParam = opts.timestampParam || 't';


### PR DESCRIPTION
Setting `path === ""` previously defaulted to `"/engine.io"` while it should use `""` instead.
