### PR TITLE
Prefer XMLHttpRequest over XDomainRequest in IE10

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -194,7 +194,7 @@ exports.request = function request (xdomain) {
   return new XMLHttpRequest();
   // end
 
-  if (xdomain && 'undefined' != typeof XDomainRequest) {
+  if (xdomain && 'undefined' != typeof XDomainRequest && !exports.ua.hasCORS) {
     return new XDomainRequest();
   }
 


### PR DESCRIPTION
E.g. if and only if XHR has withCredentials, which is the case for IE10 but not earlier IE versions.

http://msdn.microsoft.com/en-us/library/ie/hh872883(v=vs.85).aspx
