### PR TITLE
Support browserify

### DIFF
--- a/lib/transports/websocket.js
+++ b/lib/transports/websocket.js
@@ -144,7 +144,9 @@ WS.prototype.check = function () {
 
 function ws () {
   // if node
-  return require('ws');
+  try {
+    return (require)('ws');
+  } catch (err) {}
   // end
 
   return global.WebSocket || global.MozWebSocket;

--- a/lib/util.js
+++ b/lib/util.js
@@ -154,7 +154,7 @@ exports.ua.hasCORS = 'undefined' != typeof XMLHttpRequest && (function () {
  * @api private
  */
 
-exports.ua.webkit = 'undefined' != typeof navigator && 
+exports.ua.webkit = 'undefined' != typeof navigator &&
   /webkit/i.test(navigator.userAgent);
 
 /**
@@ -163,14 +163,14 @@ exports.ua.webkit = 'undefined' != typeof navigator &&
  * @api private
  */
 
-exports.ua.gecko = 'undefined' != typeof navigator && 
+exports.ua.gecko = 'undefined' != typeof navigator &&
   /gecko/i.test(navigator.userAgent);
 
 /**
  * Detect android;
  */
 
-exports.ua.android = 'undefined' != typeof navigator && 
+exports.ua.android = 'undefined' != typeof navigator &&
   /android/i.test(navigator.userAgent);
 
 /**
@@ -190,8 +190,10 @@ exports.ua.ios6 = exports.ua.ios && /OS 6_/.test(navigator.userAgent);
 
 exports.request = function request (xdomain) {
   // if node
-  var XMLHttpRequest = require('xmlhttprequest').XMLHttpRequest;
-  return new XMLHttpRequest();
+  try {
+    var XMLHttpRequest = require('xmlhttprequest').XMLHttpRequest;
+    return new XMLHttpRequest();
+  } catch (err) {}
   // end
 
   if (xdomain && 'undefined' != typeof XDomainRequest && !exports.ua.hasCORS) {
@@ -241,7 +243,7 @@ exports.parseUri = function (str) {
 /**
  * Compiles a querystring
  *
- * @param {Object} 
+ * @param {Object}
  * @api private
  */
 


### PR DESCRIPTION
Yes the implementation is ugly.

It's needed to have nice things like [`engine.io-stream`](https://github.com/Raynos/engine.io-stream) where you can open a stream connection to an engine.io server from either the browser or node with the same code.

Note that `(require)` is a hack to tell browserify not to bundle that dependency.
