### PR TITLE
fixes "failed to require "engine.io" from (...)"

### DIFF
--- a/component.json
+++ b/component.json
@@ -5,6 +5,7 @@
     "component/emitter": "0.0.6",
     "visionmedia/debug": "*"
   },
+  "main": "lib/index.js",
   "scripts": [
     "lib/index.js",
     "lib/parser.js",


### PR DESCRIPTION
From the [component/component](https://github.com/component/component) [spec](https://github.com/component/component/wiki/Spec):

> It is recommended that you use "index.js" for the main component file, however if you use another filename, you **MUST** define a "main" field for that. A component **MUST** have only one "main" file specified, and it **MUST** still be listed in the "scripts" array.
