### PR TITLE
Support browserify

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-
 module.exports = process.env.EIO_COV
-? require('./lib-cov/')
+? (require)('./lib-cov/')
 : require('./lib/');


### PR DESCRIPTION
>  Cannot find module: "./lib-cov/"

Need to add the browserify compiler "hint" which is don't try to load `lib-cov` because it won't be used in production.
