### PR TITLE
Do not shadow global XMLHttpRequest

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -108,7 +108,7 @@ var rvalidchars = /^[\],:{}\s]*$/
 
 exports.parseJSON = function (data) {
   var global = exports.global();
-  
+
   if ('string' != typeof data || !data) {
     return null;
   }
@@ -193,8 +193,8 @@ exports.ua.ios6 = exports.ua.ios && /OS 6_/.test(navigator.userAgent);
 
 exports.request = function request (xdomain) {
   if ('undefined' == typeof window) {
-    var XMLHttpRequest = require('xmlhttprequest').XMLHttpRequest;
-    return new XMLHttpRequest();
+    var _XMLHttpRequest = require('xmlhttprequest').XMLHttpRequest;
+    return new _XMLHttpRequest();
   }
 
   if (xdomain && 'undefined' != typeof XDomainRequest && !exports.ua.hasCORS) {


### PR DESCRIPTION
If you use the XMLHttpRequest variable name then the if
typeof XMLHttpRequest === 'undefined' check will always
return false and the XHR polling method is never used.

This is needed because JSONP polling is buggy and doesn't emit
close when server shutsdown. JSONP should be fixed / disabled.
