### PR TITLE
client now ignores unsupported upgrades

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -364,7 +364,7 @@ Socket.prototype.onHandshake = function (data) {
   this.emit('handshake', data);
   this.id = data.sid;
   this.transport.query.sid = data.sid;
-  this.upgrades = data.upgrades;
+  this.upgrades = this.filterUpgrades(data.upgrades);
   this.pingInterval = data.pingInterval;
   this.pingTimeout = data.pingTimeout;
   this.onOpen();
@@ -496,6 +496,22 @@ Socket.prototype.onClose = function (reason, desc) {
     this.onclose && this.onclose.call(this);
     this.id = null;
   }
+};
+
+/**
+ * Filters upgrades, returning only those matching client transports.
+ * 
+ * @param {Array} server upgrades
+ * @api private
+ *
+ */
+
+Socket.prototype.filterUpgrades = function (upgrades) {
+  var filteredUpgrades = [];
+  for (var i = 0, j = upgrades.length; i<j; i++) {
+    if (~this.transports.indexOf(upgrades[i])) filteredUpgrades.push(upgrades[i]);
+  }
+  return filteredUpgrades;
 };
 
 /**

--- a/test/socket.js
+++ b/test/socket.js
@@ -1,0 +1,11 @@
+
+describe('Socket', function () {
+
+  describe('filterUpgrades', function () {
+    it('should return only available transports', function () {
+      var socket = new eio.Socket({'transports': ['polling']});
+      expect(socket.filterUpgrades(['polling','websocket'])).to.eql(['polling']);
+    });
+  });
+
+});


### PR DESCRIPTION
currently, the client's transport setting is ignored regarding the possible protocol upgrades an engine.io server proposes.

this commit tries to fix this by filtering the proposed upgrades using the client's own transports.
