### PR TITLE
close also if socket.readyState is on "opening"

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -487,7 +487,7 @@ Socket.prototype.onError = function (err) {
  */
 
 Socket.prototype.onClose = function (reason, desc) {
-  if ('open' == this.readyState) {
+  if ('opening' == this.readyState || 'open' == this.readyState) {
     debug('socket close with reason: "%s"', reason);
     clearTimeout(this.pingIntervalTimer);
     clearTimeout(this.pingTimeoutTimer);


### PR DESCRIPTION
upon connecting to the eio server, the connection is set on 'opening', and stays there, if the eio server is not reachable. in such a state, it is currently impossible to manually close the ongoing connection. this commit tries to fix that.
