### PR TITLE
require emitter-component only

### DIFF
--- a/lib/emitter.js
+++ b/lib/emitter.js
@@ -1,15 +1,8 @@
-
 /**
  * Module dependencies.
  */
 
-var Emitter;
-
-try {
-  Emitter = require('emitter');
-} catch(e){
-  Emitter = require('emitter-component');
-}
+var Emitter = require('emitter-component');
 
 /**
  * Module exports.


### PR DESCRIPTION
It is confusing to have competing package managers within the same
require system. The rest of the code uses npm published modules; this
should too. We have tools which can bundle all of this properly
without resorting to source code confusion.
