### PR TITLE
Latest commit to engine.io-parser has broken engine.io-client

### DIFF
--- a/component.json
+++ b/component.json
@@ -3,7 +3,7 @@
   "version": "0.4.1",
   "dependencies": {
     "component/emitter": "0.0.6",
-    "LearnBoost/engine.io-protocol": "*",
+    "LearnBoost/engine.io-protocol": "0.1.1",
     "visionmedia/debug": "*"
   },
   "main": "lib/index.js",


### PR DESCRIPTION
The latest commit requires engine.io-parser to return the packet using a callback however the engine-io-client is still using the old method.
