### PR TITLE
use istanbul for code coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .DS_Store
 build
 components
+/coverage

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,12 @@ test:
 		--reporter $(REPORTER) \
 		$(TESTS)
 
+test-cov:
+	@./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha -- \
+		--require ./test/common \
+		--reporter $(REPORTER) \
+		$(TESTS)
+
 test-browser:
 	@./node_modules/.bin/serve test/
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,2 @@
 
-module.exports = process.env.EIO_COV
-? require('./lib-cov/')
-: require('./lib/');
+module.exports =  require('./lib/');

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "devDependencies": {
     "mocha": "*",
     "serve": "*",
-    "expect.js": "*"
+    "expect.js": "*",
+    "istanbul": "*"
   },
   "component": {
     "scripts": {


### PR DESCRIPTION
- Requires no instrumentation
- add `make test-cov` to generate coverage reports
