### PR TITLE
require 'emitter' versus 'emitter-component'

### DIFF
--- a/lib/emitter.js
+++ b/lib/emitter.js
@@ -3,13 +3,7 @@
  * Module dependencies.
  */
 
-var Emitter;
-
-try {
-  Emitter = require('emitter');
-} catch(e){
-  Emitter = require('emitter-component');
-}
+var Emitter = require('emitter');
 
 /**
  * Module exports.
@@ -40,13 +34,3 @@ Emitter.prototype.removeEventListener = Emitter.prototype.off;
  */
 
 Emitter.prototype.removeListener = Emitter.prototype.off;
-
-/**
- * Node-compatible `EventEmitter#removeAllListeners`
- *
- * @api public
- */
-
-Emitter.prototype.removeAllListeners = function(){
-  this._callbacks = {};
-};

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "ws": "0.4.25",
     "xmlhttprequest": "1.5.0",
-    "emitter-component": "0.0.6",
+    "emitter": "git://github.com/component/emitter#7063b6",
     "engine.io-parser": "0.2.0",
     "debug": "0.7.2"
   },


### PR DESCRIPTION
Use the github style dependency to just grab the emitter package from
github. Use the long form because short form is all sorts of broken with
npm.
