### PR TITLE
Issue 83 fix: IE9/10 error

### DIFF
--- a/lib/transports/polling-xhr.js
+++ b/lib/transports/polling-xhr.js
@@ -248,6 +248,9 @@ Request.prototype.onError = function(err){
  */
 
 Request.prototype.cleanup = function(){
+  if ('undefined' == typeof this.xhr ) {
+    return;
+  }
   // xmlhttprequest
   this.xhr.onreadystatechange = empty;
 


### PR DESCRIPTION
The problem was that this.xhr didn't exist. OP of the issue suspects that cleanup is getting called twice (once by onSuccess, the other by onError). I think just returning if the xhr is undefined/null would fix this (since there's nothing to cleanup).
