### PR TITLE
Issue 65 fix: Added eio query string

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -60,7 +60,7 @@ function Socket(uri, opts){
        location.port :
        (this.secure ? 443 : 80));
   this.query = opts.query || {};
-  this.query.eio = parser.protocol;
+  this.query.EIO = parser.protocol; // this is an int, not a string
   this.upgrade = false !== opts.upgrade;
   this.path = (opts.path || '/engine.io').replace(/\/$/, '') + '/';
   this.forceJSONP = !!opts.forceJSONP;
@@ -89,7 +89,7 @@ Emitter(Socket.prototype);
  * @api public
  */
 
-Socket.protocol = parser.protocol;
+Socket.protocol = parser.protocol; // this is an int
 
 /**
  * Static EventEmitter.


### PR DESCRIPTION
Tell me if this isn't what you intended and/or if there's anything else I need to do.

Basically I added a eio parameter to this.query that takes the version number from engine.io-parser (see Albert's pull request). Also changed Socket.protocol to take that same protocol version.

Note that you have to integrate Albert's changes to engine.io-protocol/parser, otherwise mine won't work.
