### PR TITLE
Adding Version Badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Engine.IO client
 
 [![Build Status](https://secure.travis-ci.org/LearnBoost/engine.io-client.png)](http://travis-ci.org/LearnBoost/engine.io-client)
+[![NPM version](https://badge.fury.io/js/engine.io-client.png)](http://badge.fury.io/js/engine.io-client)
 
 This is the client for [Engine](http://github.com/learnboost/engine.io), the
 implementation of transport-based cross-browser/cross-device bi-directional


### PR DESCRIPTION
As discussed with @guille over email, I'm adding the Version Badge to the README. This should help existing users and new visitors to the Github page to find out about the existence and version of the module.
