### PR TITLE
I *think* this is a typo.

### DIFF
--- a/lib/transports/websocket.js
+++ b/lib/transports/websocket.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */
@@ -95,7 +94,7 @@ WS.prototype.write = function(packets){
   }
   // check periodically if we're done sending
   if ('bufferedAmount' in this.socket) {
-    this.bufferedAmountId = this.setInterval(function() {
+    this.bufferedAmountId = setInterval(function() {
       if (self.socket.bufferedAmount == 0) {
         clearInterval(self.bufferedAmountId);
         ondrain();


### PR DESCRIPTION
Right now, whenever I try upgrading to WS, I get:

```
Uncaught TypeError: Object #<Transport> has no method 'setInterval'
```

Did a quick search for WS.prototype.setInterval and I don't see it anywhere. Removing `this` makes the upgrade work correctly.

---

Also, here's a bit of the server-side code:

``` js
var express = require('express'),
    app = express(),
    es = new engine.Server(),
    server = require('http').createServer(app);

server.on('upgrade', function(req, socket, head) {
  es.handleUpgrade(req, socket, head);
});
```
