### PR TITLE
Don't check against the window to detect node.js, wrap code in a try cat...

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -202,10 +202,10 @@ exports.ua.ios6 = exports.ua.ios && /OS 6_/.test(navigator.userAgent);
  */
 
 exports.request = function request (xdomain) {
-  if ('undefined' == typeof window) {
+  try {
     var _XMLHttpRequest = require('xmlhttprequest').XMLHttpRequest;
     return new _XMLHttpRequest();
-  }
+  } catch (e) {}
 
   if (xdomain && 'undefined' != typeof XDomainRequest && !exports.ua.hasCORS) {
     return new XDomainRequest();


### PR DESCRIPTION
Don't check against the window to detect node.js, wrap code in a try catch statement and have it degrade gracefully like the rest of the code.

Fixes #147
