### PR TITLE
fix issue/168

### DIFF
--- a/engine.io.js
+++ b/engine.io.js
@@ -1161,8 +1161,11 @@ Socket.prototype.onClose = function (reason, desc) {
     debug('socket close with reason: "%s"', reason);
     clearTimeout(this.pingIntervalTimer);
     clearTimeout(this.pingTimeoutTimer);
+    var prev = this.readyState;
     this.readyState = 'closed';
-    this.emit('close', reason, desc);
+    if (prev == 'open') {
+      this.emit('close', reason, desc);
+    }
     this.onclose && this.onclose.call(this);
     this.id = null;
   }

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -555,8 +555,11 @@ Socket.prototype.onClose = function (reason, desc) {
       self.writeBuffer = [];
       self.callbackBuffer = [];
     }, 0);
+    var prev = this.readyState;
     this.readyState = 'closed';
-    this.emit('close', reason, desc);
+    if (prev == 'open') {
+      this.emit('close', reason, desc);
+    }
     this.onclose && this.onclose.call(this);
     this.id = null;
   }

--- a/test/socket.js
+++ b/test/socket.js
@@ -8,4 +8,20 @@ describe('Socket', function () {
     });
   });
 
+  describe('socketClosing', function () {
+    it('should not emit close on incorrect connection', function (done) {
+      var socket = new eio.Socket('ws://localhost:8080');
+      var closed = false;
+
+      socket.on('close', function () {
+        closed = true;
+      });
+
+      setTimeout(function() {
+        expect(closed).to.be(false);
+        done();
+      }, 200);
+    });
+  });
+
 });


### PR DESCRIPTION
When trying to set up a connection, the readyState is 'opening'. And onClose CAN be called when the readyState was either 'opening' (trying to connect) or 'open' (when connected).

It should not be able to close on 'opening' because that means no connection is established
