### PR TITLE
use indexof component for ie8 and below

### DIFF
--- a/component.json
+++ b/component.json
@@ -3,6 +3,7 @@
   "version": "0.5.0",
   "dependencies": {
     "component/emitter": "1.0.0",
+    "component/indexof": "*",
     "LearnBoost/engine.io-protocol": "0.3.0",
     "visionmedia/debug": "*"
   },

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -6,6 +6,7 @@ var util = require('./util')
   , transports = require('./transports')
   , Emitter = require('./emitter')
   , debug = require('debug')('engine-client:socket')
+  , index = require('indexof')
   , parser = require('engine.io-parser');
 
 /**
@@ -572,7 +573,7 @@ Socket.prototype.onClose = function (reason, desc) {
 Socket.prototype.filterUpgrades = function (upgrades) {
   var filteredUpgrades = [];
   for (var i = 0, j = upgrades.length; i<j; i++) {
-    if (~this.transports.indexOf(upgrades[i])) filteredUpgrades.push(upgrades[i]);
+    if (~index(this.transports, upgrades[i])) filteredUpgrades.push(upgrades[i]);
   }
   return filteredUpgrades;
 };

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "ws": "0.4.25",
     "xmlhttprequest": "1.5.0",
     "emitter": "git://github.com/component/emitter#1.0.0",
+    "indexof": "0.0.1",
     "engine.io-parser": "0.3.0",
     "debug": "0.7.2"
   },


### PR DESCRIPTION
In IE8 and below `[].indexOf` does not exist.

It causes the error `object doesn't support this property or method`

Use the [indexof component](https://github.com/component/indexof)

Existing tests from @ruxkor cover this.

`make test` and `make test-browser` are passing.

manually tested in chrome latest and ie7-10
