### PR TITLE
Remove nested require call. Allows require.js to optimize.

### DIFF
--- a/engine.io.js
+++ b/engine.io.js
@@ -3050,7 +3050,7 @@ require.alias("engine.io/lib/index.js", "engine.io/index.js");
 if (typeof exports == "object") {
   module.exports = require("engine.io");
 } else if (typeof define == "function" && define.amd) {
-  define(function(){ return require("engine.io"); });
+  define(require("engine.io"));
 } else {
   this["eio"] = require("engine.io");
 }})();


### PR DESCRIPTION
When performing optimization require.js looks inside of define blocks for require calls (to allow for CJS-esque requires inside of AMD blocks).

It sees the call to require inside of the define block I've changed and says "I don't see that file!" and explodes.

This causes it to just see "define returns the result of an expression" instead.
