### PR TITLE
use http url in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "ws": "0.4.25",
     "xmlhttprequest": "1.5.0",
-    "emitter": "git://github.com/component/emitter#1.0.0",
+    "emitter": "http://github.com/component/emitter/archive/1.0.0.tar.gz",
     "indexof": "0.0.1",
     "engine.io-parser": "0.3.0",
     "debug": "0.7.2"


### PR DESCRIPTION
Using a git:// makes it impossible to install this on an enterprise network. We tried using a git command to replace all git:// with http:// but since you have a tag in here it doesn't work. This should solve the issue
