### PR TITLE
Update emitter dep to 1.0.1

### DIFF
--- a/component.json
+++ b/component.json
@@ -2,7 +2,7 @@
   "name": "engine.io",
   "version": "0.6.3",
   "dependencies": {
-    "component/emitter": "1.0.0",
+    "component/emitter": "1.0.1",
     "component/indexof": "*",
     "LearnBoost/engine.io-protocol": "0.3.0",
     "visionmedia/debug": "*"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "ws": "0.4.25",
     "xmlhttprequest": "1.5.0",
-    "emitter": "http://github.com/component/emitter/archive/1.0.0.tar.gz",
+    "emitter": "http://github.com/component/emitter/archive/1.0.1.tar.gz",
     "indexof": "0.0.1",
     "engine.io-parser": "0.3.0",
     "debug": "0.7.2"


### PR DESCRIPTION
Emitter 1.0.0 did not support legacy versions of IE. 1.0.1 does!

closes https://github.com/LearnBoost/engine.io-client/issues/172
