### PR TITLE
Emit errors thrown by xhr.send()

### DIFF
--- a/lib/transports/polling-xhr.js
+++ b/lib/transports/polling-xhr.js
@@ -214,9 +214,9 @@ Request.prototype.create = function(){
     // Need to defer since .create() is called directly from the constructor
     // and thus the 'error' event can only be only bound *after* this exception
     // occurs.  Therefore, also, we cannot throw here at all.
-    util.defer(function() {
+    setTimeout(function() {
       self.onError(e);
-    });
+    }, 0);
     return;
   }
 


### PR DESCRIPTION
When a user refreshes at _just_ the right moment during connection, Chrome gets stuck into a state where XHR refuses all `xhr.send()` calls with DOMException `NetworkError`.  Subsequent refreshes don't clear this error.  This PR makes sure that at least the `error` event is emitted when this happens.  The thrown exception cannot be caught since it's on a clear stack due to `util.defer()` being used.
