### PR TITLE
Don't lose packets writen during upgrade after a re-open

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -560,6 +560,7 @@ Socket.prototype.onClose = function (reason, desc) {
     setTimeout(function() {
       self.writeBuffer = [];
       self.callbackBuffer = [];
+      self.prevBufferLen = 0;
     }, 0);
 
     // ignore further transport communication


### PR DESCRIPTION
After a close, reset the prevBufferLen along with the buffers,
so a drain event after upgrade won't remove any packets that have been
queued up during upgrading.
