### PR TITLE
Updated dependencies to support Node 0.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "ws": "0.4.28",
     "xmlhttprequest": "1.5.0",
-    "emitter-component": "http://github.com/component/emitter/archive/1.0.1.tar.gz",
+    "emitter": "http://github.com/component/emitter/archive/1.0.1.tar.gz",
     "indexof": "0.0.1",
     "engine.io-parser": "0.3.0",
     "debug": "0.7.2"


### PR DESCRIPTION
ws 0.4.28 has been released, adding support for Node 0.11
