### PR TITLE
Force timestampRequests for the Chrome Frame.

### DIFF
--- a/lib/transports/polling.js
+++ b/lib/transports/polling.js
@@ -205,7 +205,7 @@ Polling.prototype.uri = function(){
   var port = '';
 
   // cache busting is forced for IE / android / iOS6 ಠ_ಠ
-  if (global.ActiveXObject || util.ua.android || util.ua.ios6 ||
+  if (global.ActiveXObject || util.ua.chromeframe || util.ua.android || util.ua.ios6 ||
       this.timestampRequests) {
     query[this.timestampParam] = +new Date;
   }

--- a/lib/util.js
+++ b/lib/util.js
@@ -176,6 +176,12 @@ exports.ua.ios = 'undefined' != typeof navigator &&
 exports.ua.ios6 = exports.ua.ios && /OS 6_/.test(navigator.userAgent);
 
 /**
+ * Detect Chrome Frame.
+ */
+
+exports.ua.chromeframe = Boolean(global.externalHost);
+
+/**
  * XHR request helper.
  *
  * @param {Boolean} whether we need xdomain


### PR DESCRIPTION
IE8 still exhibits the ridiculous caching behaviour when in Chrome Frame. This forces the timestamps for polling urls when it detects the chrome frame.
