### PR TITLE
websocket: pass `undefined` as the WebSocket "protocols"

### DIFF
--- a/lib/transports/websocket.js
+++ b/lib/transports/websocket.js
@@ -59,7 +59,7 @@ WS.prototype.doOpen = function(){
 
   var self = this;
   var uri = this.uri();
-  var protocols = [];
+  var protocols = void(0);
   var opts = { agent: this.agent };
 
   this.socket = new WebSocket(uri, protocols, opts);


### PR DESCRIPTION
Fixes on Safari 5: [![](http://i.cloudup.com/Fn2AOGvmBk.png)](https://cloudup.com/cfn0Edwkpya)
