### PR TITLE
Fixed issue which prevented IE9 and under to pass Cookies to server duri...

### DIFF
--- a/lib/transports/index.js
+++ b/lib/transports/index.js
@@ -40,7 +40,7 @@ function polling (opts) {
     var port = location.port;
 
     // some user agents have empty `location.port`
-    if (Number(port) !== port) {
+    if (!port) {
       port = isSSL ? 443 : 80;
     }
 

--- a/lib/transports/polling-xhr.js
+++ b/lib/transports/polling-xhr.js
@@ -47,7 +47,7 @@ function XHR(opts){
     var port = location.port;
 
     // some user agents have empty `location.port`
-    if (Number(port) !== port) {
+    if (!port) {
       port = isSSL ? 443 : 80;
     }
 


### PR DESCRIPTION
...ng handshake.

This is related to this issue here: https://github.com/socketstream/socketstream/issues/364.

The previous solution introduced a new bug: If using port 8000 for example, 8000 !== "8000" will evaluate to true and that will set the port to 80 and cause xs to be true.
