### PR TITLE
Make connections sticky to a node instance behind the LB

### DIFF
--- a/engine.io.js
+++ b/engine.io.js
@@ -198,6 +198,7 @@ Socket.prototype.createTransport = function (name) {
 
   // session id if we already have one
   if (this.id) query.sid = this.id;
+  if (this.wid) query.wid = this.wid;
 
   var transport = new transports[name]({
     agent: this.agent,
@@ -439,7 +440,9 @@ Socket.prototype.onPacket = function (packet) {
 Socket.prototype.onHandshake = function (data) {
   this.emit('handshake', data);
   this.id = data.sid;
+  this.wid = data.wid;
   this.transport.query.sid = data.sid;
+  this.transport.query.wid = data.wid;
   this.upgrades = this.filterUpgrades(data.upgrades);
   this.pingInterval = data.pingInterval;
   this.pingTimeout = data.pingTimeout;

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -142,6 +142,7 @@ Socket.prototype.createTransport = function (name) {
 
   // session id if we already have one
   if (this.id) query.sid = this.id;
+  if (this.wid) query.wid = this.wid;
 
   var transport = new transports[name]({
     agent: this.agent,
@@ -383,7 +384,9 @@ Socket.prototype.onPacket = function (packet) {
 Socket.prototype.onHandshake = function (data) {
   this.emit('handshake', data);
   this.id = data.sid;
+  this.wid = data.wid;
   this.transport.query.sid = data.sid;
+  this.transport.query.wid = data.wid;
   this.upgrades = this.filterUpgrades(data.upgrades);
   this.pingInterval = data.pingInterval;
   this.pingTimeout = data.pingTimeout;


### PR DESCRIPTION
To support LearnBoost/engine.io#207
Load balancers can use worker id to target a specific node instance behind the LB.
