### PR TITLE
allow changing URI on socket (re)open()

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,11 @@ Exposed as `eio` in the browser standalone build.
       - `Function`: optional, callback upon `drain`
 - `close`
     - Disconnects the client.
+- `open`
+    - Reopen the existing socket
+    - **Parameters**
+      - `String` uri: optional, if you wish a different URI from the constructor or
+        previous `open`
 
 ### Transport
 

--- a/engine.io.js
+++ b/engine.io.js
@@ -103,31 +103,9 @@ function Socket(uri, opts){
     uri = null;
   }
 
-  if (uri) {
-    uri = util.parseUri(uri);
-    opts.host = uri.host;
-    opts.secure = uri.protocol == 'https' || uri.protocol == 'wss';
-    opts.port = uri.port;
-    if (uri.query) opts.query = uri.query;
-  }
-
-  this.secure = null != opts.secure ? opts.secure :
-    (global.location && 'https:' == location.protocol);
-
-  if (opts.host) {
-    var pieces = opts.host.split(':');
-    opts.hostname = pieces.shift();
-    if (pieces.length) opts.port = pieces.pop();
-  }
+  this.processUri(uri);
 
   this.agent = opts.agent || false;
-  this.hostname = opts.hostname ||
-    (global.location ? location.hostname : 'localhost');
-  this.port = opts.port || (global.location && location.port ?
-       location.port :
-       (this.secure ? 443 : 80));
-  this.query = opts.query || {};
-  if ('string' == typeof this.query) this.query = util.qsParse(this.query);
   this.upgrade = false !== opts.upgrade;
   this.path = (opts.path || '/engine.io').replace(/\/$/, '') + '/';
   this.forceJSONP = !!opts.forceJSONP;
@@ -186,6 +164,34 @@ Socket.parser = require('engine.io-parser');
  * @api private
  */
 
+Socket.prototype.processUri = function(uri) {
+  var host, port, secure, query, hostname;
+  if (uri) {
+    uri = util.parseUri(uri);
+    host = uri.host;
+    secure = uri.protocol == 'https' || uri.protocol == 'wss';
+    port = uri.port;
+    if (uri.query) query = uri.query;
+  }
+
+  this.secure = undefined != secure ? secure :
+    (global.location && 'https:' == location.protocol);
+
+  if (host) {
+    var pieces = host.split(':');
+    hostname = pieces.shift();
+    if (pieces.length) port = pieces.pop();
+  }
+
+  this.hostname = hostname ||
+    (global.location ? location.hostname : 'localhost');
+  this.port = port || (global.location && location.port ?
+       location.port :
+       (this.secure ? 443 : 80));
+  this.query = query || {};
+  if ('string' == typeof this.query) this.query = util.qsParse(this.query);
+};
+
 Socket.prototype.createTransport = function (name) {
   debug('creating transport "%s"', name);
   var query = clone(this.query);
@@ -232,9 +238,8 @@ function clone (obj) {
  * @api private
  */
 
-Socket.prototype.open = function (queryString) {
-  this.query = queryString || this.query;
-  if ('string' == typeof this.query) this.query = util.qsParse(this.query);
+Socket.prototype.open = function (uri) {
+  if (uri) this.processUri(uri);
   var transport = this.transports[0];
   this.readyState = 'opening';
   var transport = this.createTransport(transport);

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -47,31 +47,9 @@ function Socket(uri, opts){
     uri = null;
   }
 
-  if (uri) {
-    uri = util.parseUri(uri);
-    opts.host = uri.host;
-    opts.secure = uri.protocol == 'https' || uri.protocol == 'wss';
-    opts.port = uri.port;
-    if (uri.query) opts.query = uri.query;
-  }
-
-  this.secure = null != opts.secure ? opts.secure :
-    (global.location && 'https:' == location.protocol);
-
-  if (opts.host) {
-    var pieces = opts.host.split(':');
-    opts.hostname = pieces.shift();
-    if (pieces.length) opts.port = pieces.pop();
-  }
+  this.processUri(uri);
 
   this.agent = opts.agent || false;
-  this.hostname = opts.hostname ||
-    (global.location ? location.hostname : 'localhost');
-  this.port = opts.port || (global.location && location.port ?
-       location.port :
-       (this.secure ? 443 : 80));
-  this.query = opts.query || {};
-  if ('string' == typeof this.query) this.query = util.qsParse(this.query);
   this.upgrade = false !== opts.upgrade;
   this.path = (opts.path || '/engine.io').replace(/\/$/, '') + '/';
   this.forceJSONP = !!opts.forceJSONP;
@@ -130,6 +108,34 @@ Socket.parser = require('engine.io-parser');
  * @api private
  */
 
+Socket.prototype.processUri = function(uri) {
+  var host, port, secure, query, hostname;
+  if (uri) {
+    uri = util.parseUri(uri);
+    host = uri.host;
+    secure = uri.protocol == 'https' || uri.protocol == 'wss';
+    port = uri.port;
+    if (uri.query) query = uri.query;
+  }
+
+  this.secure = undefined != secure ? secure :
+    (global.location && 'https:' == location.protocol);
+
+  if (host) {
+    var pieces = host.split(':');
+    hostname = pieces.shift();
+    if (pieces.length) port = pieces.pop();
+  }
+
+  this.hostname = hostname ||
+    (global.location ? location.hostname : 'localhost');
+  this.port = port || (global.location && location.port ?
+       location.port :
+       (this.secure ? 443 : 80));
+  this.query = query || {};
+  if ('string' == typeof this.query) this.query = util.qsParse(this.query);
+};
+
 Socket.prototype.createTransport = function (name) {
   debug('creating transport "%s"', name);
   var query = clone(this.query);
@@ -176,9 +182,8 @@ function clone (obj) {
  * @api private
  */
 
-Socket.prototype.open = function (queryString) {
-  this.query = queryString || this.query;
-  if ('string' == typeof this.query) this.query = util.qsParse(this.query);
+Socket.prototype.open = function (uri) {
+  if (uri) this.processUri(uri);
   var transport = this.transports[0];
   this.readyState = 'opening';
   var transport = this.createTransport(transport);


### PR DESCRIPTION
Allow setting a new query string on socket (re)open(). This is mainly to enable hinting to load balancers/proxies.
It may be discussed whether:
1) we should enable changing the entire URI on re-open or
2) the user should destroy and construct a new Socket per such reconnect (too heavy handed in my opinion. Note on a mobile device this may happen every time the user clicks the home button, phone call/text received, etc ).

For now I just added query string modification, we can discuss option 1.
*\* implemented full URI change in final PR
