### PR TITLE
update to has-cors 1.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   ],
   "dependencies": {
     "global": "https://github.com/component/global/archive/v2.0.1.tar.gz",
-    "has-cors": "https://github.com/component/has-cors/archive/v1.0.2.tar.gz",
+    "has-cors": "1.0.3",
     "ws": "0.4.31",
     "xmlhttprequest": "https://github.com/LearnBoost/node-XMLHttpRequest/archive/0f36d0b5ebc03d85f860d42a64ae9791e1daa433.tar.gz",
     "emitter": "http://github.com/component/emitter/archive/1.0.1.tar.gz",


### PR DESCRIPTION
Fixes graceful fallback if XMLHttp request is disabled in IE

see issue #44

I think this might be as close as we will get to testing this. I ran the test suite in IE 8 with disabled XMLHttp request. The result is the `new XMLHttpRequest` throws. I only had to patch up `has-cors` to account for that and the test suite passes. We already have logic for a throwing XMLHttpRequest so I think we are all set.
