### PR TITLE
Use !this.xhr for testing in cleanup method

### DIFF
--- a/engine.io.js
+++ b/engine.io.js
@@ -1582,7 +1582,8 @@ Request.prototype.onError = function(err){
  */
 
 Request.prototype.cleanup = function(){
-  if ('undefined' == typeof this.xhr ) {
+  // !this.xhr is used to check both undefined and null, see issue #180
+  if (!this.xhr) {
     return;
   }
   // xmlhttprequest


### PR DESCRIPTION
(!this.xhr) is used to check both undefined and null, see issue #180 

However, since Request module is private, I couldn't figure out a way to write a test case either :/
