### PR TITLE
Force timestamping for sockets

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,9 +160,8 @@ Exposed as `eio` in the browser standalone build.
       to upgrade the transport from long-polling to something better.
       - `forceJSONP` (`Boolean`): forces JSONP for polling transport.
       - `forceBase64` (`Boolean`): forces base 64 encoding for polling transport even when XHR2 responseType is available and WebSocket even if the used standard supports binary.
-      - `timestampRequests` (`Boolean`): whether to add the timestamp with
-        each transport request. Note: this is ignored if the browser is
-        IE or Android, in which case requests are always stamped (`false`)
+      - `timestampRequests` (`Boolean`): defaults to true, whether to add the
+      timestamp with each transport request.
       - `timestampParam` (`String`): timestamp parameter (`t`)
       - `flashPath` (`String`): path to flash client files with trailing slash
       - `policyPort` (`Number`): port the policy server listens on (`843`)

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -77,7 +77,7 @@ function Socket(uri, opts){
   this.forceJSONP = !!opts.forceJSONP;
   this.forceBase64 = !!opts.forceBase64;
   this.timestampParam = opts.timestampParam || 't';
-  this.timestampRequests = opts.timestampRequests;
+  this.timestampRequests = opts.timestampRequests !== false;
   this.flashPath = opts.flashPath || '';
   this.transports = opts.transports || ['polling', 'websocket', 'flashsocket'];
   this.readyState = '';

--- a/lib/transports/polling.js
+++ b/lib/transports/polling.js
@@ -224,15 +224,8 @@ Polling.prototype.uri = function(){
   var schema = this.secure ? 'https' : 'http';
   var port = '';
 
-  // cache busting is forced for IE / android / iOS6 ಠ_ಠ
-  if ('ActiveXObject' in global
-    || util.ua.chromeframe
-    || util.ua.android
-    || util.ua.ios6
-    || this.timestampRequests) {
-    if (false !== this.timestampRequests) {
-      query[this.timestampParam] = +new Date;
-    }
+  if (this.timestampRequests) {
+    query[this.timestampParam] = +new Date;
   }
 
   if (!this.supportsBinary && !query.sid) {

--- a/test/socket.js
+++ b/test/socket.js
@@ -30,4 +30,30 @@ describe('Socket', function () {
     });
   });
 
+  it('should give sockets different ids or mandate timestamps', function(done) {
+    var sockets = [];
+    var remaining, total;
+    // Create this many sockets during this event loop
+    remaining = total = 4;
+    for (var i = 0; i < total; i++)
+    {
+      sockets[i] = new eio.Socket();
+      sockets[i].on('open', function() {
+        remaining--;
+        if (remaining == 0) {
+          // Ensure sockets don't have same ids, if they are not using time stamps
+          for (var j = 0; j < sockets.length; j++) {
+            for (var k = j + 1; k < sockets.length; k++) {
+              if (!sockets[j].timestampRequests && !sockets[k].timestampRequests) {
+                expect(sockets[j].id).not.to.equal(sockets[k].id);
+              }
+            }
+            sockets[j].close();
+          }
+          done();
+        }
+      });
+    }
+  });
+
 });


### PR DESCRIPTION
This addresses issue #245. Test-case for consecutively-created sockets not being forced to timestamp and then having the session ids.

Want to make sure I have the correct idea here. What's the proper way of forcing timestampRequests?
