### PR TITLE
Don't override empty opts.port

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -67,9 +67,12 @@ function Socket(uri, opts){
   this.agent = opts.agent || false;
   this.hostname = opts.hostname ||
     (global.location ? location.hostname : 'localhost');
-  this.port = opts.port || (global.location && location.port ?
-       location.port :
-       (this.secure ? 443 : 80));
+  if (opts.port || opts.port === '') {
+    this.port = opts.port;
+  } else {
+    this.port = global.location && location.port ?
+        location.port : (this.secure ? 443 : 80);
+  }
   this.query = opts.query || {};
   if ('string' == typeof this.query) this.query = util.qsParse(this.query);
   this.upgrade = false !== opts.upgrade;

--- a/test/socket.js
+++ b/test/socket.js
@@ -12,6 +12,13 @@ describe('Socket', function () {
     });
   });
 
+  describe('socketOpening', function() {
+    it('should not override empty port in uri', function () {
+      var socket = new eio.Socket('ws://0.0.0.0');
+      expect(socket.port).to.be('');
+    });
+  });
+
   describe('socketClosing', function(){
     it('should emit close on incorrect connection', function(done){
       var socket = new eio.Socket('ws://0.0.0.0:8080');


### PR DESCRIPTION
This tests for and addresses issue #156.
