### PR TITLE
parseUri() regex split up into smaller regexes

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -160,10 +160,28 @@ exports.ua.chromeframe = Boolean(global.externalHost);
  * Parses an URI
  *
  * @author Steven Levithan <stevenlevithan.com> (MIT license)
+ *         http://stevenlevithan.com/demo/parseuri/cf/
  * @api private
  */
 
-var re = /^(?:(?![^:@]+:[^:@\/]*@)(http|https|ws|wss):\/\/)?((?:(([^:@]*)(?::([^:@]*))?)?@)?((?:[a-f0-9]{0,4}:){2,7}[a-f0-9]{0,4}|[^:\/?#]*)(?::(\d*))?)(((\/(?:[^?#](?![^?#\/]*\.[^?#\/.]+(?:[?#]|$)))*\/?)?([^?#\/]*))(?:\?([^#]*))?(?:#(.*))?)/;
+var protocol = /(?:(?![^:@]+:[^:@\/]*@)(http|https|ws|wss):\/\/)?/;
+var user = /([^:@]*)/;
+var password = /(?::([^:@]*))?/;
+var userInfo = new RegExp('(?:(' + user.source + password.source + ')?@)?');
+var host = /((?:[a-f0-9]{0,4}:){2,7}[a-f0-9]{0,4}|[^:\/?#]*)/;
+var port = /(?::(\d*))?/;
+var authority =
+  new RegExp('(' + userInfo.source + host.source + port.source + ')');
+var directory = /(\/(?:[^?#](?![^?#\/]*\.[^?#\/.]+(?:[?#]|$)))*\/?)?/;
+var file = /([^?#\/]*)/;
+var path = new RegExp('(' + directory.source + file.source + ')');
+var query = /(?:\?([^#]*))?/;
+var anchor = /(?:#(.*))?/;
+var relative =
+  new RegExp('(' + path.source + query.source + anchor.source + ')');
+
+var re = new RegExp('^' + protocol.source + authority.source
+                  + relative.source);
 
 var parts = [
     'source', 'protocol', 'authority', 'userInfo', 'user', 'password', 'host'


### PR DESCRIPTION
As a follow-up to #247, I figured that since I understand that giant regex in `parseUri`, I should break it up into smaller regexes, rather than one regex to rule them all. Hopefully this will make future edits more reasonable.

The resulting regex is identical:

```
var protocol = /(?:(?![^:@]+:[^:@\/]*@)(http|https|ws|wss):\/\/)?/;
var user = /([^:@]*)/;
var password = /(?::([^:@]*))?/;
var userInfo = new RegExp('(?:(' + user.source + password.source + ')?@)?');
// e.g. www.google.com. The [a-f0-9] part is for ipv6
var host = /((?:[a-f0-9]{0,4}:){2,7}[a-f0-9]{0,4}|[^:\/?#]*)/;
var port = /(?::(\d*))?/;
var authority =
  new RegExp('(' + userInfo.source + host.source + port.source + ')');

var directory = /(\/(?:[^?#](?![^?#\/]*\.[^?#\/.]+(?:[?#]|$)))*\/?)?/;
var file = /([^?#\/]*)/;
var path = new RegExp('(' + directory.source + file.source + ')');
var query = /(?:\?([^#]*))?/;
var anchor = /(?:#(.*))?/;
var relative =
  new RegExp('(' + path.source + query.source + anchor.source + ')');

var re = new RegExp('^' + protocol.source + authority.source
                  + relative.source);

var oldRe = /^(?:(?![^:@]+:[^:@\/]*@)(http|https|ws|wss):\/\/)?((?:(([^:@]*)(?::([^:@]*))?)?@)?((?:[a-f0-9]{0,4}:){2,7}[a-f0-9]{0,4}|[^:\/?#]*)(?::(\d*))?)(((\/(?:[^?#](?![^?#\/]*\.[^?#\/.]+(?:[?#]|$)))*\/?)?([^?#\/]*))(?:\?([^#]*))?(?:#(.*))?)/;

undefined

re.source === oldRe.source

true
```
