### PR TITLE
Fix browserify options

### DIFF
--- a/support/browserify.js
+++ b/support/browserify.js
@@ -20,8 +20,9 @@ module.exports = build;
 
 
 function build(fn){
-  var opts = {};
-  opts.builtins = false;
-  opts.insertGlobals = 'global';
-  browserify(path, opts).bundle({ standalone: 'eio' }, fn);
+  var opts = {
+    builtins: false,
+    entries: [path]
+  };
+  browserify(opts).bundle({ standalone: 'eio' }, fn);
 }


### PR DESCRIPTION
`insertGlobals` is a bundle option and should be passed in the `bundle` method.
Now it is passed to the browserify constructor and it has no effect.
That option has a boolean value according to [browserify documentation](https://github.com/substack/node-browserify#bbundleopts-cb) and is `false` by default.

I think that `detectGlobals` (enabled by default) does what `insertGlobals` was meant to do here.
