### PR TITLE
Not base64 encoding for no reason when using websockets

### DIFF
--- a/lib/transports/websocket.js
+++ b/lib/transports/websocket.js
@@ -75,7 +75,7 @@ WS.prototype.doOpen = function(){
 
   this.ws = new WebSocket(uri, protocols, opts);
 
-  if (this.ws.binaryType !== undefined) {
+  if (this.ws.binaryType === undefined) {
     this.supportsBinary = false;
   }
 


### PR DESCRIPTION
We're missing some crucial tests that make sure we're using the expected encoding/decoding for situtations. I'll write up some tests to make sure this doesn't happen again.
