### PR TITLE
Added android as a browser for testing fixed tests accordingly

### DIFF
--- a/.zuul.yml
+++ b/.zuul.yml
@@ -16,3 +16,5 @@ browsers:
     version: [6..9, latest]
   - name: iphone
     version: oldest..latest
+  - name: android
+    version: latest

--- a/test/arraybuffer/index.js
+++ b/test/arraybuffer/index.js
@@ -3,6 +3,7 @@ var wsSupport = require('has-cors');
 require('./polling.js');
 var uagent = navigator.userAgent;
 var isOldSimulator = ~uagent.indexOf('iPhone OS 4') || ~uagent.indexOf('iPhone OS 5');
-if (wsSupport && !isOldSimulator) {
+var isAndroid = navigator.userAgent.match(/Android/i);
+if (wsSupport && !isOldSimulator && !isAndroid) {
   require ('./ws.js');
 }

--- a/test/blob/index.js
+++ b/test/blob/index.js
@@ -3,6 +3,7 @@ var wsSupport = require('has-cors');
 require('./polling.js');
 var uagent = navigator.userAgent;
 var isOldSimulator = ~uagent.indexOf('iPhone OS 4') || ~uagent.indexOf('iPhone OS 5');
-if (wsSupport && !isOldSimulator) {
+var isAndroid = navigator.userAgent.match(/Android/i);
+if (wsSupport && !isOldSimulator && !isAndroid) {
   require('./ws.js');
 }

--- a/test/blob/polling.js
+++ b/test/blob/polling.js
@@ -18,7 +18,7 @@ describe('blob', function() {
       socket.on('message', function (data) {
         if (typeof data === 'string') return;
 
-        expect(data).to.be.a(Blob);
+        expect(data).to.be.a(global.Blob);
         var fr = new FileReader();
         fr.onload = function() {
           var ab = this.result;


### PR DESCRIPTION
This PR requires https://github.com/LearnBoost/engine.io-parser/pull/8 to be merged. It adds android to the browsers used for testing in saucelabs, and introduces a couple necessary fixes to the tests to make them pass on android too. 

It seems that WebSocket connections do not work on the android emulator. At least when I try making connections, and upgrade event is never fired. This is why ws tests are disabled for android browsers.
