### PR TITLE
polling: ensure that the timestamp used for cache busting is unique

### DIFF
--- a/lib/transport.js
+++ b/lib/transport.js
@@ -39,6 +39,13 @@ function Transport (opts) {
 Emitter(Transport.prototype);
 
 /**
+ * A counter used to prevent collisions in the timestamps used
+ * for cache busting.
+ */
+
+Transport.timestamps = 0;
+
+/**
  * Emits an error.
  *
  * @param {String} str

--- a/lib/transports/polling.js
+++ b/lib/transports/polling.js
@@ -225,7 +225,7 @@ Polling.prototype.uri = function(){
     || util.ua.ios6
     || this.timestampRequests) {
     if (false !== this.timestampRequests) {
-      query[this.timestampParam] = +new Date;
+      query[this.timestampParam] = +new Date + '-' + Transport.timestamps++;
     }
   }
 


### PR DESCRIPTION
This fixes https://github.com/LearnBoost/engine.io/issues/233.
The problem there was that the new request was being made with the same timestamp, generating a little request loop that lasted until a different timestamp was generated.

The same thing is done here https://github.com/LearnBoost/engine.io-client/blob/bab992d0f78d12de2696c21df0862da0714ab2f1/lib/transports/websocket.js#L194 but i don't know if the fix is required for the websocket transport, i think that it doesn't make sense in this case.
