### PR TITLE
[fix] new XMLHttpRequest always returns an object

### DIFF
--- a/lib/transports/index.js
+++ b/lib/transports/index.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies
  */
@@ -43,7 +42,7 @@ function polling (opts) {
   opts.xdomain = xd;
   xhr = new XMLHttpRequest(opts);
 
-  if (xhr && !opts.forceJSONP) {
+  if ('open' in xhr && !opts.forceJSONP) {
     return new XHR(opts);
   } else {
     return new JSONP(opts);


### PR DESCRIPTION
The `XMLHttpRequest` is a function that **might** return an XHR or ActiveX object. As it's invoked using `new XMLHttpRequest` it will always return an object and it will never be null. So doing a for the `open` method should ensure that the correct transport is used.
