### PR TITLE
polling-xhr: abort the request when the window is unloaded

### DIFF
--- a/lib/transports/polling-xhr.js
+++ b/lib/transports/polling-xhr.js
@@ -16,12 +16,6 @@ module.exports = XHR;
 module.exports.Request = Request;
 
 /**
- * Obfuscated key for Blue Coat.
- */
-
-var hasAttachEvent = !!(global.document && global.document.attachEvent);
-
-/**
  * Empty function
  */
 
@@ -218,7 +212,7 @@ Request.prototype.create = function(isBinary, supportsBinary){
     return;
   }
 
-  if (hasAttachEvent) {
+  if (global.document) {
     this.index = Request.requestsCount++;
     Request.requests[this.index] = this;
   }
@@ -274,7 +268,7 @@ Request.prototype.cleanup = function(){
     this.xhr.abort();
   } catch(e) {}
 
-  if (hasAttachEvent) {
+  if (global.document) {
     delete Request.requests[this.index];
   }
 
@@ -292,14 +286,19 @@ Request.prototype.abort = function(){
 };
 
 /**
- * Cleanup is needed for old versions of IE
- * that leak memory unless we abort request before unload.
+ * Cleanup is needed for IE that leaks memory unless we abort the request
+ * before unload. It is also needed to prevent spurious errors from being
+ * emimtted.
  */
 
-if (hasAttachEvent) {
+if (global.document) {
   Request.requestsCount = 0;
   Request.requests = {};
-  global.attachEvent('onunload', unloadHandler);
+  if (global.document.attachEvent) {
+    global.attachEvent('onunload', unloadHandler);
+  } else {
+    global.addEventListener('beforeunload', unloadHandler);
+  }
 }
 
 function unloadHandler() {


### PR DESCRIPTION
It seems that the cleanup originally planned only for old versions of IE is also needed for IE10/11.

To show the issue i have started a basic engine.io server here http://mezzase.ga/. The code of the server is this:

``` javascript
var fs = require('fs')
  , http = require('http');

var server = http.createServer(function (req, res) {
  if (req.url === '/client.js') {
    res.setHeader('Content-Type', 'application/javascript');
    fs.createReadStream(__dirname + '/client.js').pipe(res);
    return;
  }
  if (req.url === '/engine.io.js') {
    res.setHeader('Content-Type', 'application/javascript');
    fs.createReadStream(__dirname + '/engine.io.js').pipe(res);
    return;
  }
  res.setHeader('Content-Type', 'text/html');
  fs.createReadStream(__dirname + '/index.html').pipe(res);
});

var io = require('engine.io').attach(server);

io.on('connection', function (socket) {
  socket.send('bar');
});

server.listen(80, function () {
  console.log('server listening on port 80');
});
```

Then i connect to the server using IE11 from another domain. To test this i've put this `index.html` in my public dropbox folder.

``` html
<!DOCTYPE html>
<html>
  <head></head>
  <body>
    <script src="http://mezzase.ga/engine.io.js"></script>
    <script src="http://mezzase.ga/client.js"></script>
  </body>
</html>
```

You can find it here http://dl.dropboxusercontent.com/u/58444696/index.html.
If you open that url in IE11 and start refreshing the page at some point you will get errors like this:

![about-blank](https://cloud.githubusercontent.com/assets/1443911/2625400/fce7fb34-bd93-11e3-9d14-aabd66e32f75.png)

The proposed patch fixes the issue ensuring that the pending opened request is closed when the window is unloaded. This is done for all browsers, not only IE because if the cleanup is done for all browsers it also fixes issue #282.
