### PR TITLE
Fix double firing of close event when explicitly closing a socket

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -575,6 +575,9 @@ Socket.prototype.onClose = function (reason, desc) {
       self.prevBufferLen = 0;
     }, 0);
 
+    // stop event from firing again for transport
+    this.transport.removeAllListeners('close');
+
     // ensure transport won't stay open
     this.transport.close();
 
@@ -589,6 +592,7 @@ Socket.prototype.onClose = function (reason, desc) {
 
     // emit close event
     this.emit('close', reason, desc);
+
     this.onclose && this.onclose.call(this);
   }
 };


### PR DESCRIPTION
If you bump engine.io version to use this engine.io-client commit, tests pass. The reason they were failing before was that close event was fired twice on explicit closes: once for force close and once for the transport.
