### PR TITLE
polling-xhr: fix a comment and remove unneeded `document` reference

### DIFF
--- a/lib/transports/polling-xhr.js
+++ b/lib/transports/polling-xhr.js
@@ -286,15 +286,15 @@ Request.prototype.abort = function(){
 };
 
 /**
- * Cleanup is needed for IE that leaks memory unless we abort the request
- * before unload. It is also needed to prevent spurious errors from being
- * emimtted.
+ * Aborts pending requests when unloading the window. This is needed to prevent
+ * memory leaks (e.g. when using IE) and to ensure that no spurious error is
+ * emitted.
  */
 
 if (global.document) {
   Request.requestsCount = 0;
   Request.requests = {};
-  if (global.document.attachEvent) {
+  if (global.attachEvent) {
     global.attachEvent('onunload', unloadHandler);
   } else if (global.addEventListener) {
     global.addEventListener('beforeunload', unloadHandler);


### PR DESCRIPTION
This should improve the comment block mentioned in #283.
