### PR TITLE
polling-jsonp: prevent spurious errors from being emitted when the window is unloaded

### DIFF
--- a/lib/transports/polling-jsonp.js
+++ b/lib/transports/polling-jsonp.js
@@ -67,6 +67,13 @@ function JSONPPolling (opts) {
 
   // append to query string
   this.query.j = this.index;
+
+  // prevent spurious errors from being emitted when the window is unloaded
+  if (global.document && global.addEventListener) {
+    global.addEventListener('beforeunload', function () {
+      if (self.script) self.script.onerror = empty;
+    });
+  }
 }
 
 /**
@@ -82,7 +89,7 @@ util.inherits(JSONPPolling, Polling);
 JSONPPolling.prototype.supportsBinary = false;
 
 /**
- * Closes the socket
+ * Closes the socket.
  *
  * @api private
  */
@@ -108,7 +115,7 @@ JSONPPolling.prototype.doClose = function () {
  */
 
 JSONPPolling.prototype.doPoll = function () {
-	var self = this;
+  var self = this;
   var script = document.createElement('script');
 
   if (this.script) {
@@ -125,7 +132,6 @@ JSONPPolling.prototype.doPoll = function () {
   var insertAt = document.getElementsByTagName('script')[0];
   insertAt.parentNode.insertBefore(script, insertAt);
   this.script = script;
-
 
   if (util.ua.gecko) {
     setTimeout(function () {


### PR DESCRIPTION
Very similar to #283.
The patch ensures that no spurious error is emitted when the window is unloaded.

Fixes https://github.com/LearnBoost/engine.io/issues/247.
