### PR TITLE
JSONP transport fails when sending JSON stringified message 

### DIFF
--- a/lib/transports/polling-jsonp.js
+++ b/lib/transports/polling-jsonp.js
@@ -17,6 +17,7 @@ module.exports = JSONPPolling;
  */
 
 var rNewline = /\n/g;
+var rEscapedNewline = /\\n/g;
 
 /**
  * Global JSONP callbacks.
@@ -211,6 +212,8 @@ JSONPPolling.prototype.doWrite = function (data, fn) {
   initIframe();
 
   // escape \n to prevent it from being converted into \r\n by some UAs
+  // double escaping is required for escaped new lines because unescaping of new lines can be done safely on server-side
+  data = data.replace(rEscapedNewline, '\\\n');
   this.area.value = data.replace(rNewline, '\\n');
 
   try {


### PR DESCRIPTION
JSONP transport fails when sending JSON stringified message, due to unescape mismatch

Code to reproduce the issue

``` JavaScript
var socket = eio('ws://localhost:9999', {
  forceJSONP : true
});

socket.on('open', function(){
  socket.send(JSON.stringify({
    a : 'c\nd'
  }));
});
```

An escaped message (e.g. '{a:"c\\nd"}') does not get escaped by https://github.com/LearnBoost/engine.io-client/blob/master/lib/transports/polling-jsonp.js#L214 but gets unescaped by https://github.com/LearnBoost/engine.io/blob/master/lib/transports/polling-jsonp.js#L46
Resulting in parse error due to invalid payload length and invalid json
