### PR TITLE
Upgrade component-emitter to 1.1.2, fix #305

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -3,7 +3,7 @@
  */
 
 var transports = require('./transports');
-var Emitter = require('emitter');
+var Emitter = require('component-emitter');
 var debug = require('debug')('engine.io-client:socket');
 var index = require('indexof');
 var parser = require('engine.io-parser');

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -3,7 +3,7 @@
  */
 
 var parser = require('engine.io-parser');
-var Emitter = require('emitter');
+var Emitter = require('component-emitter');
 
 /**
  * Module exports.

--- a/lib/transports/polling-xhr.js
+++ b/lib/transports/polling-xhr.js
@@ -4,7 +4,7 @@
 
 var XMLHttpRequest = require('xmlhttprequest');
 var Polling = require('./polling');
-var Emitter = require('emitter');
+var Emitter = require('component-emitter');
 var debug = require('debug')('engine.io-client:polling-xhr');
 var inherit = require('inherits');
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "has-cors": "1.0.3",
     "ws": "0.4.31",
     "xmlhttprequest": "https://github.com/LearnBoost/node-XMLHttpRequest/archive/0f36d0b5ebc03d85f860d42a64ae9791e1daa433.tar.gz",
-    "emitter": "http://github.com/component/emitter/archive/1.0.1.tar.gz",
+    "component-emitter": "1.1.2",
     "indexof": "0.0.1",
     "engine.io-parser": "1.0.6",
     "debug": "0.7.4",


### PR DESCRIPTION
Switch from depending on a tarball URL to the published component-emitter package at its latest version.

Change all references to emitter module to the new component-emitter name.

Fix #305. /cc @defunctzombie
