### PR TITLE
smaller inherits utility

### DIFF
--- a/lib/transports/polling-jsonp.js
+++ b/lib/transports/polling-jsonp.js
@@ -4,7 +4,7 @@
  */
 
 var Polling = require('./polling');
-var inherit = require('inherits');
+var inherit = require('component-inherit');
 
 /**
  * Module exports.

--- a/lib/transports/polling-xhr.js
+++ b/lib/transports/polling-xhr.js
@@ -5,8 +5,8 @@
 var XMLHttpRequest = require('xmlhttprequest');
 var Polling = require('./polling');
 var Emitter = require('component-emitter');
+var inherit = require('component-inherit');
 var debug = require('debug')('engine.io-client:polling-xhr');
-var inherit = require('inherits');
 
 /**
  * Module exports.

--- a/lib/transports/polling.js
+++ b/lib/transports/polling.js
@@ -5,8 +5,8 @@
 var Transport = require('../transport');
 var parseqs = require('parseqs');
 var parser = require('engine.io-parser');
+var inherit = require('component-inherit');
 var debug = require('debug')('engine.io-client:polling');
-var inherit = require('inherits');
 
 /**
  * Module exports.

--- a/lib/transports/websocket.js
+++ b/lib/transports/websocket.js
@@ -5,8 +5,8 @@
 var Transport = require('../transport');
 var parser = require('engine.io-parser');
 var parseqs = require('parseqs');
+var inherit = require('component-inherit');
 var debug = require('debug')('engine.io-client:websocket');
-var inherit = require('inherits');
 
 /**
  * `ws` exposes a WebSocket-compatible interface in

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "parseuri": "0.0.2",
     "parsejson": "0.0.1",
     "parseqs": "0.0.2",
-    "inherits": "2.0.1"
+    "component-inherit": "0.0.3"
   },
   "devDependencies": {
     "zuul": "1.6.3",


### PR DESCRIPTION
- Ditch `inherits` that breaks MooTools (https://github.com/Automattic/socket.io-client/issues/689#issuecomment-45448536)
- Implement smaller, simpler inherits utility
