### PR TITLE
Fixed error 'Cannot read property name of null' which happened occasiona...

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -257,7 +257,6 @@ Socket.prototype.probe = function (name) {
           self.setTransport(transport);
           transport.send([{ type: 'upgrade' }]);
           self.emit('upgrade', transport);
-          transport = null;
           self.upgrading = false;
           self.flush();
         });
@@ -275,11 +274,8 @@ Socket.prototype.probe = function (name) {
 
     // Any callback called by transport should be ignored since now
     failed = true;
-
     cleanup();
-
     transport.close();
-    transport = null;
   }
 
   //Handle any error that happens while probing


### PR DESCRIPTION
...lly while spawning many concurrent clients (from Node.js) for stress test.
This error happened often when I had 100+ concurrent clients running in Node.js.

Could be a race condition... In any case, we probably shouldn't assume that the transport variable is set since other parts of the code explicitly set it to null under certain conditions.
