### PR TITLE
Possibility to disable JSONP.

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -71,7 +71,7 @@ function Socket(uri, opts){
   this.upgrade = false !== opts.upgrade;
   this.path = (opts.path || '/engine.io').replace(/\/$/, '') + '/';
   this.forceJSONP = !!opts.forceJSONP;
-  this.jsonp = null == opts.jsonp ? true : !!opts.jsonp;
+  this.jsonp = false !== opts.jsonp;
   this.forceBase64 = !!opts.forceBase64;
   this.timestampParam = opts.timestampParam || 't';
   this.timestampRequests = opts.timestampRequests;

--- a/lib/transports/index.js
+++ b/lib/transports/index.js
@@ -24,7 +24,7 @@ exports.websocket = websocket;
 function polling(opts){
   var xhr;
   var xd = false;
-  var jsonp = null == opts.jsonp ? true : opts.jsonp;
+  var jsonp = false !== opts.jsonp;
 
   if (global.location) {
     var isSSL = 'https:' == location.protocol;

--- a/test/connection.js
+++ b/test/connection.js
@@ -87,6 +87,7 @@ describe('connection', function() {
 
       socket.on('open', function() {
         expect(socket.transport.name).to.be('websocket');
+        socket.close();
         done();
       });
     });


### PR DESCRIPTION
A first pass at being able to disable JSONP polling. Totally up for discussion.

Enables disabling by an option `noJSONP` that can be set to `true` (`false` by default). If set to true and trying to open a polling connection, we move immediately to a possible next transport. If there is not transport left to open with, we emit an error that no transports are available.

We could make our polling transports also not autodetectable as `xhr` and `json` so that we could specify transport literals like: `['xhr', 'websocket']` to specify we don't want JSONP polling as an option. This would, however, complicate the handling of transports and upgrades and I'm not sure if it's worth it for this one edge case.

Thoughts on this @guille?
