### PR TITLE
Remove try-catch for utf8 decode errors

### DIFF
--- a/lib/transport.js
+++ b/lib/transport.js
@@ -125,13 +125,8 @@ Transport.prototype.onOpen = function () {
  */
 
 Transport.prototype.onData = function(data){
-  try {
-    var packet = parser.decodePacket(data, this.socket.binaryType);
-    this.onPacket(packet);
-  } catch(e){
-    e.data = data;
-    this.onError('parser decode error', e);
-  }
+  var packet = parser.decodePacket(data, this.socket.binaryType);
+  this.onPacket(packet);
 };
 
 /**


### PR DESCRIPTION
Catching invalid utf8 errors would not be necessary after the following PR is used:

https://github.com/Automattic/engine.io-parser/pull/29

And it looks like that calling `onError` causes a socket to be closed. I think it's too much for handling a decode error anyway.
