### PR TITLE
Defer close while upgrading a transport

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -261,6 +261,7 @@ Socket.prototype.probe = function (name) {
         debug('probe transport "%s" pong', name);
         self.upgrading = true;
         self.emit('upgrading', transport);
+        if (!transport) return;
         Socket.priorWebsocketSuccess = 'websocket' == transport.name;
 
         debug('pausing current transport "%s"', self.transport.name);
@@ -534,10 +535,6 @@ Socket.prototype.flush = function () {
 
 Socket.prototype.write =
 Socket.prototype.send = function (msg, fn) {
-  if ('closing' == this.readyState || 'closed' == this.readyState) {
-    return;
-  }
-
   this.sendPacket('message', msg, fn);
   return this;
 };
@@ -552,6 +549,10 @@ Socket.prototype.send = function (msg, fn) {
  */
 
 Socket.prototype.sendPacket = function (type, data, fn) {
+  if ('closing' == this.readyState || 'closed' == this.readyState) {
+    return;
+  }
+
   var packet = { type: type, data: data };
   this.emit('packetCreate', packet);
   this.writeBuffer.push(packet);
@@ -570,15 +571,23 @@ Socket.prototype.close = function () {
     this.readyState = 'closing';
 
     var self = this;
+
     function close() {
       self.onClose('forced close');
       debug('socket closing - telling transport to close');
       self.transport.close();
     }
 
+    function cleanupAndClose() {
+      self.removeListener('upgrade', cleanupAndClose);
+      self.removeListener('upgradeError', cleanupAndClose);
+      close();
+    }
+
     if (this.upgrading) {
-      // wait to upgrade since we can't send packets while pausing a transport
-      this.on('upgrade', close);
+      // wait for upgrade to finish since we can't send packets while pausing a transport
+      this.once('upgrade', cleanupAndClose);
+      this.once('upgradeError', cleanupAndClose);
     } else {
       close();
     }


### PR DESCRIPTION
https://github.com/Automattic/socket.io/issues/1668

Wait for upgrade to finish since a close packet can't be sent while pausing a transport. 
I'm not so confident yet, but we need to add `closing` readyState for making clear the current state.
