### PR TITLE
update parseuri version

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "indexof": "0.0.1",
     "engine.io-parser": "1.1.0",
     "debug": "0.7.4",
-    "parseuri": "0.0.2",
+    "parseuri": "0.0.4",
     "parsejson": "0.0.1",
     "parseqs": "0.0.2",
     "component-inherit": "0.0.3"


### PR DESCRIPTION
Merged pull request by @hellpf to parseuri get/parseuri#6 following issue Automattic/engine.io#269. This updated version of parseuri adds support for IPv6 URI's.
