### PR TITLE
Force xhr-polling and disable xdomain option for early IE versions

### DIFF
--- a/lib/transports/index.js
+++ b/lib/transports/index.js
@@ -8,6 +8,12 @@ var JSONP = require('./polling-jsonp');
 var websocket = require('./websocket');
 
 /**
+ * Check if we are running old version of IE (<8) to force using
+ * XHR-polling to avoid "clicking" noise when sending data
+ */
+ var isEarlyIE = navigator.userAgent.match (/MSIE [6-8]/);
+
+/**
  * Export transports.
  */
 
@@ -41,7 +47,7 @@ function polling(opts){
   opts.xdomain = xd;
   xhr = new XMLHttpRequest(opts);
 
-  if ('open' in xhr && !opts.forceJSONP) {
+  if ('open' in xhr && !opts.forceJSONP || isEarlyIE) {
     return new XHR(opts);
   } else {
     if (!jsonp) throw new Error('JSONP disabled');

--- a/lib/transports/polling-xhr.js
+++ b/lib/transports/polling-xhr.js
@@ -22,6 +22,12 @@ module.exports.Request = Request;
 function empty(){}
 
 /**
+ * Check if we are running old version of IE (<8) to disable
+ * unsupported cross-domain XHR-polling option
+ */
+ var isEarlyIE = navigator.userAgent.match (/MSIE [6-8]/);
+
+/**
  * XHR Polling constructor.
  *
  * @param {Object} opts
@@ -67,7 +73,7 @@ XHR.prototype.supportsBinary = true;
 XHR.prototype.request = function(opts){
   opts = opts || {};
   opts.uri = this.uri();
-  opts.xd = this.xd;
+  opts.xd = this.xd && !isEarlyIE;
   opts.agent = this.agent || false;
   opts.supportsBinary = this.supportsBinary;
   return new Request(opts);


### PR DESCRIPTION
Force xhr-polling and disable xdomain option for ie 6,7,8 to avoid annoying click sound and loading bar flashing on sending data
