### PR TITLE
check enablesXDR option when Request.hasXDR is called just in case

### DIFF
--- a/lib/transports/polling-xhr.js
+++ b/lib/transports/polling-xhr.js
@@ -313,7 +313,7 @@ Request.prototype.onLoad = function(){
  */
 
 Request.prototype.hasXDR = function(){
-  return 'undefined' !== typeof global.XDomainRequest && !this.xs;
+  return 'undefined' !== typeof global.XDomainRequest && !this.xs && this.enablesXDR;
 };
 
 /**

--- a/test/index.js
+++ b/test/index.js
@@ -17,6 +17,7 @@ require('./transport');
 // browser only tests
 if (env.browser) {
   require('./connection');
+  require('./transports');
   require('./xmlhttprequest');
   if (global.ArrayBuffer) {
     require('./arraybuffer');

--- a/test/transports/index.js
+++ b/test/transports/index.js
@@ -1,0 +1,1 @@
+require ('./polling-xhr.js');

--- a/test/transports/polling-xhr.js
+++ b/test/transports/polling-xhr.js
@@ -1,0 +1,59 @@
+var expect = require('expect.js');
+var XHR = require('../../lib/transports/polling-xhr');
+var isIE8 = /MSIE 8/.test(navigator.userAgent);
+
+describe('XHR', function() {
+  describe('Request', function() {
+    describe('hasXDR', function() {
+      if (isIE8) {
+        it('should return true when xscheme is false and enablesXDR is true', function() {
+          var request = new XHR.Request({
+            uri: "http://localhost/engine.io?sid=test"
+          , xd: true
+          , xs: false
+          , enablesXDR: true
+          });
+          expect(request.hasXDR()).to.be(true);
+        });
+
+        it('should return false when xscheme is true', function() {
+          var request;
+          request = new XHR.Request({
+            uri: "http://localhost/engine.io?sid=test"
+          , xd: true
+          , xs: true
+          , enablesXDR: true
+          });
+          expect(request.hasXDR()).to.be(false);
+
+          request = new XHR.Request({
+            uri: "http://localhost/engine.io?sid=test"
+          , xd: true
+          , xs: true
+          , enablesXDR: true
+          });
+          expect(request.hasXDR()).to.be(false);
+        });
+
+        it('should return false when enablesXDR is false', function() {
+          var request;
+          request = new XHR.Request({
+            uri: "http://localhost/engine.io?sid=test"
+          , xd: true
+          , xs: true
+          , enablesXDR: false
+          });
+          expect(request.hasXDR()).to.be(false);
+
+          request = new XHR.Request({
+            uri: "http://localhost/engine.io?sid=test"
+          , xd: true
+          , xs: false
+          , enablesXDR: false
+          });
+          expect(request.hasXDR()).to.be(false);
+        });
+      }
+    });
+  });
+});


### PR DESCRIPTION
Add a fix to primus/primus#282 together with https://github.com/Automattic/engine.io-client/pull/333.
It should work without this fix because IE8 uses jsonp-polling when enablesXDR is false, but this way makes more sense, and possibly avoid bugs in future.
