### PR TITLE
IE10 should prefer using XHR2 over XDR because it's safer

### DIFF
--- a/lib/xmlhttprequest.js
+++ b/lib/xmlhttprequest.js
@@ -12,19 +12,19 @@ module.exports = function(opts) {
   // https://github.com/Automattic/engine.io-client/pull/217
   var enablesXDR = opts.enablesXDR;
 
+  // XMLHttpRequest can be disabled on IE
+  try {
+    if ('undefined' != typeof XMLHttpRequest && (!xdomain || hasCORS)) {
+      return new XMLHttpRequest();
+    }
+  } catch (e) { }
+
   // Use XDomainRequest for IE8 if enablesXDR is true
   // because loading bar keeps flashing when using jsonp-polling
   // https://github.com/yujiosaka/socke.io-ie8-loading-example
   try {
     if ('undefined' != typeof XDomainRequest && !xscheme && enablesXDR) {
       return new XDomainRequest();
-    }
-  } catch (e) { }
-
-  // XMLHttpRequest can be disabled on IE
-  try {
-    if ('undefined' != typeof XMLHttpRequest && (!xdomain || hasCORS)) {
-      return new XMLHttpRequest();
     }
   } catch (e) { }
 

--- a/test/xmlhttprequest.js
+++ b/test/xmlhttprequest.js
@@ -1,31 +1,82 @@
 var expect = require('expect.js');
 var XMLHttpRequest = require('../lib/xmlhttprequest');
-var isIE8 = /MSIE 8/.test(navigator.userAgent);
+var isIE8_9 = /MSIE (8|9)/.test(navigator.userAgent);
+var isIE10_11 = /MSIE 10|Trident.*rv[ :]*11\./.test(navigator.userAgent);
 
 describe('XMLHttpRequest', function () {
 
-  if (isIE8) {
-    describe('IE8', function() {
-      it('should have same properties as XDomainRequest does when enablesXDR is true and xscheme is false', function() {
-        var xhr = new XMLHttpRequest({xdomain: false, xscheme: false, enablesXDR: true});
-        expect(xhr).to.be.an('object');
-        expect(xhr).to.have.property('onload');
-        expect(xhr).to.have.property('onerror');
+  if (isIE8_9) {
+    describe('IE8_9', function() {
+      context('when xdomain is false', function() {
+        it('should have same properties as XMLHttpRequest does', function() {
+          var xhra = new XMLHttpRequest({xdomain: false, xscheme: false, enablesXDR: false});
+          expect(xhra).to.be.an('object');
+          expect(xhra).to.have.property('open');
+          expect(xhra).to.have.property('onreadystatechange');
+          var xhrb = new XMLHttpRequest({xdomain: false, xscheme: false, enablesXDR: true});
+          expect(xhrb).to.be.an('object');
+          expect(xhrb).to.have.property('open');
+          expect(xhrb).to.have.property('onreadystatechange');
+         var xhrc = new XMLHttpRequest({xdomain: false, xscheme: true, enablesXDR: false});
+          expect(xhrc).to.be.an('object');
+          expect(xhrc).to.have.property('open');
+          expect(xhrc).to.have.property('onreadystatechange');
+         var xhrd = new XMLHttpRequest({xdomain: false, xscheme: true, enablesXDR: true});
+          expect(xhrd).to.be.an('object');
+          expect(xhrd).to.have.property('open');
+          expect(xhrd).to.have.property('onreadystatechange');
+        });
       });
 
-      it('should have same properties as XMLHttpRequest does when both enablesXDR and xscheme are true', function() {
-        var xhr = new XMLHttpRequest({xdomain: false, xscheme: true, enablesXDR: true});
-        expect(xhr).to.be.an('object');
-        expect(xhr).to.have.property('onreadystatechange');
-      });
+      context('when xdomain is true', function() {
+        context('when xscheme is false and enablesXDR is true', function() {
+          it('should have same properties as XDomainRequest does', function() {
+            var xhr = new XMLHttpRequest({xdomain: true, xscheme: false, enablesXDR: true});
+            expect(xhr).to.be.an('object');
+            expect(xhr).to.have.property('open');
+            expect(xhr).to.have.property('onload');
+            expect(xhr).to.have.property('onerror');
+          });
+        });
 
-      it('should have same properties as XMLHttpRequest does when enablesXDR is false', function() {
-        var xhra = new XMLHttpRequest({xdomain: false, xscheme: false});
-        expect(xhra).to.be.an('object');
-        expect(xhra).to.have.property('onreadystatechange');
-        var xhrb = new XMLHttpRequest({xdomain: false, xscheme: true});
-        expect(xhrb).to.be.an('object');
-        expect(xhrb).to.have.property('onreadystatechange');
+        context('when xscheme is true', function() {
+          it('should not have open in properties', function() {
+            var xhra = new XMLHttpRequest({xdomain: true, xscheme: true, enablesXDR: false});
+            expect(xhra).to.be.an('object');
+            expect(xhra).not.to.have.property('open');
+            var xhrb = new XMLHttpRequest({xdomain: true, xscheme: true, enablesXDR: true});
+            expect(xhrb).to.be.an('object');
+            expect(xhrb).not.to.have.property('open');
+          });
+        });
+
+        context('when enablesXDR is false', function() {
+          it('should not have open in properties', function() {
+            var xhra = new XMLHttpRequest({xdomain: true, xscheme: false, enablesXDR: false});
+            expect(xhra).to.be.an('object');
+            expect(xhra).not.to.have.property('open');
+            var xhrb = new XMLHttpRequest({xdomain: true, xscheme: true, enablesXDR: false});
+            expect(xhrb).to.be.an('object');
+            expect(xhrb).not.to.have.property('open');
+          });
+        });
+      });
+    });
+  }
+
+  if (isIE10_11) {
+    describe('IE10_11', function() {
+      context('when enablesXDR is true and xscheme is false', function() {
+        it('should have same properties as XMLHttpRequest does', function() {
+          var xhra = new XMLHttpRequest({xdomain: false, xscheme: false, enablesXDR: true});
+          expect(xhra).to.be.an('object');
+          expect(xhra).to.have.property('open');
+          expect(xhra).to.have.property('onreadystatechange');
+          var xhrb = new XMLHttpRequest({xdomain: true, xscheme: false, enablesXDR: true});
+          expect(xhrb).to.be.an('object');
+          expect(xhrb).to.have.property('open');
+          expect(xhrb).to.have.property('onreadystatechange');
+        });
       });
     });
   }


### PR DESCRIPTION
IE10 supports both XMLHttpRequest Level2 and XDomainRequest.
When enablesXDR option is set true, it tries to use XDR first. However, it should prefer XHR2 to XDR because XHR2 does not have such issues as not sending cookies, etc.
