### PR TITLE
Bump debug module

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "component-emitter": "1.1.2",
     "indexof": "0.0.1",
     "engine.io-parser": "1.1.0",
-    "debug": "0.7.4",
+    "debug": "1.0.4",
     "parseuri": "0.0.4",
     "parsejson": "0.0.1",
     "parseqs": "0.0.2",


### PR DESCRIPTION
Refer to #321 
BTW, `debug` is at `v2.0.0` now, should we use that version? If yes, I will bump it to latest.
