### PR TITLE
Fixed "jsonp polling iframe removal error" on connection close

### DIFF
--- a/lib/transports/polling-jsonp.js
+++ b/lib/transports/polling-jsonp.js
@@ -104,6 +104,7 @@ JSONPPolling.prototype.doClose = function () {
   if (this.form) {
     this.form.parentNode.removeChild(this.form);
     this.form = null;
+    this.iframe = null;
   }
 
   Polling.prototype.doClose.call(this);


### PR DESCRIPTION
When using the polling transport with JSONP and the server closes the connection, the client will be stuck in an endless `jsonp polling iframe removal error` loop until the stack is full.

![screen shot 2014-09-30 at 12 35 48](https://cloud.githubusercontent.com/assets/446063/4456788/98fba02c-488e-11e4-9ed5-b390e0ca560f.png)

**Reason:**

In the `JSONPPolling.prototype.doClose` method, the form that contains the hidden iframe is removed from the DOM. Next time the `initIframe` method is entered (in `JSONPPolling.prototype.doWrite`), it will try to remove the `iframe` which is stored in `self.iframe` but isn't attached to the DOM anymore since the parent `form` has already been destroyed. This leads to the exception.

**Fix:**

I fixed this by clearing the reference to the `iframe` in `JSONPPolling.prototype.doClose` after the `form` was removed.

This bug is most likely related and fixed by this pull request: https://github.com/Automattic/socket.io/issues/1738
