### PR TITLE
wait for buffer to be drained before closing

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -586,7 +586,9 @@ Socket.prototype.close = function () {
       close();
     }
 
-    if (this.upgrading) {
+    if (this.writeBuffer.length) {
+      this.once('drain', close);
+    } else if (this.upgrading) {
       // wait for upgrade to finish since we can't send packets while pausing a transport
       this.once('upgrade', cleanupAndClose);
       this.once('upgradeError', cleanupAndClose);

--- a/test/connection.js
+++ b/test/connection.js
@@ -143,5 +143,18 @@ describe('connection', function() {
         }, 1200);
       });
     });
+
+    it('should send all buffered packets if closing is deferred', function(done) {
+      var socket = new eio.Socket();
+      socket.on('open', function() {
+        socket.on('upgrading', function() {
+          socket.send('hi');
+          socket.close();
+        }).on('close', function() {
+          expect(socket.writeBuffer).to.have.length(0);
+          done();
+        });
+      });
+    });
   }
 });


### PR DESCRIPTION
When a socket sends packets and closes while upgrading a transport, those packets remain to be treated.
I changed to wait the drain event before actual closing on that situation. Sorry for the delay.

related issues: https://github.com/Automattic/engine.io/issues/284 https://github.com/Automattic/engine.io-client/pull/324
