### PR TITLE
remove invalid value for strict mode

### DIFF
--- a/lib/transports/polling.js
+++ b/lib/transports/polling.js
@@ -20,7 +20,7 @@ module.exports = Polling;
 
 var hasXHR2 = (function() {
   var XMLHttpRequest = require('xmlhttprequest');
-  var xhr = new XMLHttpRequest({ agent: this.agent, xdomain: false });
+  var xhr = new XMLHttpRequest({ xdomain: false });
   return null != xhr.responseType;
 })();
 


### PR DESCRIPTION
fix #344.

I think `this.agent` is always `undefined`, so we can just remove it.
