### PR TITLE
support: make the build system work with the latest browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,14 +35,16 @@
     "component-inherit": "0.0.3"
   },
   "devDependencies": {
-    "zuul": "1.10.2",
-    "mocha": "1.16.2",
-    "expect.js": "0.2.0",
-    "istanbul": "0.2.3",
-    "browserify": "4.2.1",
+    "blob": "0.0.2",
+    "browserify": "6.2.0",
+    "concat-stream": "1.4.6",
+    "derequire": "1.2.0",
     "engine.io": "1.4.2",
+    "expect.js": "0.2.0",
     "express": "3.4.8",
-    "blob": "0.0.2"
+    "istanbul": "0.2.3",
+    "mocha": "1.16.2",
+    "zuul": "1.10.2"
   },
   "scripts": {
     "test": "make test"

--- a/support/browserify.js
+++ b/support/browserify.js
@@ -4,6 +4,8 @@
  */
 
 var browserify = require('browserify');
+var derequire = require('derequire');
+var concat = require('concat-stream');
 var path = require.resolve('../');
 
 /**
@@ -20,13 +22,20 @@ module.exports = build;
 
 
 function build(fn){
-  var opts = {};
-  opts.builtins = false;
-  opts.entries = [path];
-  var bundle = {};
-  bundle.standalone = 'eio';
-  bundle.insertGlobalVars = { global: glob };
-  browserify(opts).bundle(bundle, fn);
+  var bundle = browserify({
+    builtins: false,
+    entries: [ path ],
+    insertGlobalVars: { global: glob },
+    standalone: 'eio'
+  }).bundle();
+
+  bundle.on('error', function (err) {
+    fn(err);
+  });
+
+  bundle.pipe(concat({ encoding: 'string' }, function (out) {
+    fn(null, derequire(out));
+  }));
 }
 
 /**


### PR DESCRIPTION
There are two reasons for this update:
1. A simpler interface. All the options are in the same place, no more confusion with bundle options and browserify options.
2. Performances and improvements.
