### PR TITLE
support ipv6 addresses in client connections

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -55,11 +55,17 @@ function Socket(uri, opts){
     (global.location && 'https:' == location.protocol);
 
   if (opts.host) {
-    var pieces = opts.host.split(':');
-    opts.hostname = pieces.shift();
-    if (pieces.length) {
-      opts.port = pieces.pop();
-    } else if (!opts.port) {
+    if (uri && uri.ipv6uri) {
+      opts.hostname = '[' + opts.host + ']';
+    } else {
+      var pieces = opts.host.split(':');
+      opts.hostname = pieces.shift();
+      if (pieces.length) {
+        opts.port = pieces.pop();
+      }
+    }
+
+    if (!opts.port) {
       // if no port is specified manually, use the protocol default
       opts.port = this.secure ? '443' : '80';
     }


### PR DESCRIPTION
Set the hostname properly for the client connection when trying to connect to a server with an ipv6 address in the uri