### PR TITLE
version bumped up to refresh npm regisry

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "engine.io-client",
   "description": "Client for the realtime Engine",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "homepage": "http://socket.io",
   "contributors": [
     {


### PR DESCRIPTION
As 'ws' version was changed to "0.7.1", npm install still receives old revision.
So we need to bump version number to fix it.