### PR TITLE
Enable supportsBinary when running as a node client

### DIFF
--- a/lib/transports/websocket.js
+++ b/lib/transports/websocket.js
@@ -93,7 +93,13 @@ WS.prototype.doOpen = function(){
     this.supportsBinary = false;
   }
 
-  this.ws.binaryType = 'arraybuffer';
+  if (this.ws.supports && this.ws.supports.binary) {
+    this.supportsBinary = true;
+    this.ws.binaryType = 'buffer';
+  } else {
+    this.ws.binaryType = 'arraybuffer';
+  }
+
   this.addEventListeners();
 };
 


### PR DESCRIPTION
Currently engine.io-client base64 encodes binary payloads when running as a node client. This change makes it use buffers instead which improves performance.