### PR TITLE
Enable to run most tests on Node environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ test:
 test-node:
 	@./node_modules/.bin/mocha \
 		--reporter $(REPORTER) \
+		--require test/support/server.js \
 		test/index.js
 
 test-zuul:

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "xmlhttprequest": "https://github.com/rase-/node-XMLHttpRequest/archive/a6b6f2.tar.gz",
     "component-emitter": "1.1.2",
     "indexof": "0.0.1",
-    "engine.io-parser": "1.2.1",
+    "engine.io-parser": "nkzawa/engine.io-parser#patch-3",
     "debug": "2.1.3",
     "parseuri": "0.0.4",
     "parsejson": "0.0.1",

--- a/test/arraybuffer/index.js
+++ b/test/arraybuffer/index.js
@@ -1,10 +1,6 @@
-var wsSupport = require('has-cors');
+var env = require('../support/env');
 
 require('./polling.js');
-var uagent = navigator.userAgent;
-var isOldSimulator = ~uagent.indexOf('iPhone OS 4') || ~uagent.indexOf('iPhone OS 5');
-var isIE11 = !!navigator.userAgent.match(/Trident.*rv[ :]*11\./); // ws doesn't work at all in sauce labs
-var isAndroid = navigator.userAgent.match(/Android/i);
-if (wsSupport && !isOldSimulator && !isAndroid && !isIE11) {
+if (env.wsSupport && !env.isOldSimulator && !env.isAndroid && !env.isIE11) {
   require ('./ws.js');
 }

--- a/test/arraybuffer/polling.js
+++ b/test/arraybuffer/polling.js
@@ -10,6 +10,7 @@ describe('arraybuffer', function() {
       binaryData[i] = i;
     }
     var socket = new eio.Socket({ transports: ['polling'] });
+    socket.binaryType = 'arraybuffer';
     socket.on('open', function() {
       socket.send(binaryData);
       socket.on('message', function (data) {
@@ -31,6 +32,7 @@ describe('arraybuffer', function() {
 
     var msg = 0;
     var socket = new eio.Socket({ transports: ['polling'] });
+    socket.binaryType = 'arraybuffer';
     socket.on('open', function() {
       socket.send(binaryData);
       socket.send('cash money €€€');
@@ -56,6 +58,7 @@ describe('arraybuffer', function() {
       binaryData[i] = i;
     }
     var socket = new eio.Socket({ forceBase64: true });
+    socket.binaryType = 'arraybuffer';
     socket.on('open', function() {
       socket.send(binaryData);
       socket.on('message', function (data) {

--- a/test/arraybuffer/ws.js
+++ b/test/arraybuffer/ws.js
@@ -10,6 +10,7 @@ describe('arraybuffer', function() {
       binaryData[i] = i;
     }
     var socket = new eio.Socket();
+    socket.binaryType = 'arraybuffer';
     socket.on('open', function() {
       socket.on('upgrade', function() {
         socket.send(binaryData);
@@ -34,6 +35,7 @@ describe('arraybuffer', function() {
 
     var msg = 0;
     var socket = new eio.Socket();
+    socket.binaryType = 'arraybuffer';
     socket.on('open', function() {
       socket.on('upgrade', function() {
         socket.send(binaryData);
@@ -61,6 +63,7 @@ describe('arraybuffer', function() {
       binaryData[i] = i;
     }
     var socket = new eio.Socket({ forceBase64: true });
+    socket.binaryType = 'arraybuffer';
     socket.on('open', function() {
       socket.on('upgrade', function() {
         socket.send(binaryData);

--- a/test/blob/index.js
+++ b/test/blob/index.js
@@ -1,10 +1,6 @@
-var wsSupport = require('has-cors');
+var env = require('../support/env');
 
 require('./polling.js');
-var uagent = navigator.userAgent;
-var isOldSimulator = ~uagent.indexOf('iPhone OS 4') || ~uagent.indexOf('iPhone OS 5');
-var isIE11 = !!navigator.userAgent.match(/Trident.*rv[ :]*11\./); // ws doesn't work at all in sauce labs
-var isAndroid = navigator.userAgent.match(/Android/i);
-if (wsSupport && !isOldSimulator && !isAndroid && !isIE11) {
+if (env.wsSupport && !env.isOldSimulator && !env.isAndroid && !env.isIE11) {
   require('./ws.js');
 }

--- a/test/connection.js
+++ b/test/connection.js
@@ -1,11 +1,6 @@
 var expect = require('expect.js');
 var eio = require('../');
-
-var wsSupport = require('has-cors');
-var uagent = navigator.userAgent;
-var isOldSimulator = ~uagent.indexOf('iPhone OS 4') || ~uagent.indexOf('iPhone OS 5');
-var isIE11 = !!navigator.userAgent.match(/Trident.*rv[ :]*11\./); // ws doesn't work at all in sauce labs
-var isAndroid = navigator.userAgent.match(/Android/i);
+var env = require('./support/env');
 
 describe('connection', function() {
   this.timeout(20000);
@@ -82,7 +77,7 @@ describe('connection', function() {
     });
   });
 
-  if (wsSupport && !isOldSimulator && !isAndroid && !isIE11) {
+  if (env.wsSupport && !env.isOldSimulator && !env.isAndroid && !env.isIE11) {
     it('should connect with ws when JSONP forced and disabled', function(done) {
       var socket = eio.Socket({ transports: ['polling', 'websocket'], forceJSONP: true, jsonp: false });
 

--- a/test/index.js
+++ b/test/index.js
@@ -1,31 +1,23 @@
-var env = require('./support/env');
+require('./support/env');
 
 // whitelist some globals to avoid warnings
-global.__eio = null;
 global.___eio = null;
-global.WEB_SOCKET_LOGGER = null;
-global.WEB_SOCKET_SUPPRESS_CROSS_DOMAIN_SWF_ERROR = null;
-global.WEB_SOCKET_DISABLE_AUTO_INITIALIZATION = null;
-global.WEB_SOCKET_SWF_LOCATION = null;
 
 var Blob = require('blob');
 
 require('./engine.io-client');
 require('./socket');
 require('./transport');
+require('./connection');
+require('./transports');
+require('./xmlhttprequest');
 
-// browser only tests
-if (env.browser) {
-  require('./connection');
-  require('./transports');
-  require('./xmlhttprequest');
-  if (global.ArrayBuffer) {
-    require('./arraybuffer');
-  } else {
-    require('./binary-fallback');
-  }
+if (global.ArrayBuffer) {
+  require('./arraybuffer');
+} else {
+  require('./binary-fallback');
+}
 
-  if (Blob) {
-    require('./blob');
-  }
+if (Blob) {
+  require('./blob');
 }

--- a/test/support/env.js
+++ b/test/support/env.js
@@ -2,4 +2,21 @@
 // we only do this in our tests because we need to test engine.io-client
 // support in browsers and in node.js
 // some tests do not yet work in both
-module.exports.browser = !!global.window;
+exports.browser = !!global.window;
+exports.wsSupport = !!require('ws');
+
+var userAgent = global.navigator ? navigator.userAgent : '';
+exports.isOldSimulator = ~userAgent.indexOf('iPhone OS 4') || ~userAgent.indexOf('iPhone OS 5');
+exports.isIE8 = /MSIE 8/.test(userAgent);
+exports.isIE9 = /MSIE 9/.test(userAgent);
+exports.isIE10 = /MSIE 10/.test(userAgent);
+exports.isIE11 = !!userAgent.match(/Trident.*rv[ :]*11\./); // ws doesn't work at all in sauce labs
+exports.isAndroid = userAgent.match(/Android/i);
+
+if (!global.location) {
+  global.location = {
+    hostname: 'localhost',
+    port: 3000
+  };
+}
+

--- a/test/support/server.js
+++ b/test/support/server.js
@@ -7,7 +7,7 @@ var http = require('http').Server(app);
 var server = require('engine.io').attach(http, {'pingInterval': 500});
 var browserify = require('../../support/browserify');
 
-http.listen(process.env.ZUUL_PORT);
+http.listen(process.env.ZUUL_PORT || 3000);
 
 // server worker.js as raw file
 app.use('/test/support', express.static(join(__dirname, 'public')));

--- a/test/transports/polling-xhr.js
+++ b/test/transports/polling-xhr.js
@@ -1,11 +1,11 @@
 var expect = require('expect.js');
 var XHR = require('../../lib/transports/polling-xhr');
-var isIE8 = /MSIE 8/.test(navigator.userAgent);
+var env = require('../support/env');
 
 describe('XHR', function() {
   describe('Request', function() {
     describe('hasXDR', function() {
-      if (isIE8) {
+      if (env.isIE8) {
         it('should return true when xscheme is false and enablesXDR is true', function() {
           var request = new XHR.Request({
             uri: "http://localhost/engine.io?sid=test"

--- a/test/xmlhttprequest.js
+++ b/test/xmlhttprequest.js
@@ -1,11 +1,10 @@
 var expect = require('expect.js');
 var XMLHttpRequest = require('../lib/xmlhttprequest');
-var isIE8_9 = /MSIE (8|9)/.test(navigator.userAgent);
-var isIE10_11 = /MSIE 10|Trident.*rv[ :]*11\./.test(navigator.userAgent);
+var env = require('./support/env');
 
 describe('XMLHttpRequest', function () {
 
-  if (isIE8_9) {
+  if (env.isIE8 || env.isIE9) {
     describe('IE8_9', function() {
       context('when xdomain is false', function() {
         it('should have same properties as XMLHttpRequest does', function() {
@@ -64,7 +63,7 @@ describe('XMLHttpRequest', function () {
     });
   }
 
-  if (isIE10_11) {
+  if (env.isIE10 || env.isIE11) {
     describe('IE10_11', function() {
       context('when enablesXDR is true and xscheme is false', function() {
         it('should have same properties as XMLHttpRequest does', function() {


### PR DESCRIPTION
Requires `test/support/server.js` when mocha starts, so that we can run almost all test cases on Node.js environment too. 