### PR TITLE
Fix Function.prototype.apply throws error with TypedArray on some old browsers

### DIFF
--- a/lib/transports/polling-xhr.js
+++ b/lib/transports/polling-xhr.js
@@ -346,7 +346,12 @@ Request.prototype.onLoad = function(){
       if (!this.supportsBinary) {
         data = this.xhr.responseText;
       } else {
-        data = String.fromCharCode.apply(null, new Uint8Array(this.xhr.response));
+        var arr = new Uint8Array(this.xhr.response);
+        var codes = [];
+        for (var i = 0, len = arr.length; i < len; i++) {
+          codes.push(arr[i]);
+        }
+        data = String.fromCharCode.apply(null, codes);
       }
     }
   } catch (e) {


### PR DESCRIPTION
This causes our test failures on Android 4.0 and iPhone 5.1.

TypedError: '[object Uint8Array]' is not a valid argument for 'Function.prototype.apply'

