### PR TITLE
package: remove 'xmlhttprequest' dep to restore fix from #396

### DIFF
--- a/lib/transports/polling-xhr.js
+++ b/lib/transports/polling-xhr.js
@@ -346,7 +346,17 @@ Request.prototype.onLoad = function(){
       if (!this.supportsBinary) {
         data = this.xhr.responseText;
       } else {
-        data = String.fromCharCode.apply(null, new Uint8Array(this.xhr.response));
+        try {
+          data = String.fromCharCode.apply(null, new Uint8Array(this.xhr.response));
+        } catch (e) {
+          var ui8Arr = new Uint8Array(this.xhr.response);
+          var dataArray = [];
+          for (var idx = 0, length = ui8Arr.legnth; idx < length; idx++) {
+            dataArray.push(ui8Arr[idx]);
+          }
+
+          data = String.fromCharCode.apply(null, dataArray);
+        }
       }
     }
   } catch (e) {

--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
     "parseuri": "0.0.4",
     "parsejson": "0.0.1",
     "parseqs": "0.0.2",
-    "parseuri": "0.0.4",
-    "ws": "0.7.2",
-    "xmlhttprequest": "https://github.com/rase-/node-XMLHttpRequest/archive/a6b6f2.tar.gz"
+    "component-inherit": "0.0.3"
   },
   "devDependencies": {
     "blob": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     }
   ],
   "dependencies": {
-    "has-cors": "1.0.3",
+    "has-cors": "1.1.0",
     "ws": "0.7.2",
     "xmlhttprequest-ssl": "1.5.1",
     "component-emitter": "1.1.2",


### PR DESCRIPTION
 remove duplicate deps
 re-add component-inherit

Closes #384, closes #358, closes #348

Commit [709554f](https://github.com/socketio/engine.io-client/commit/709554f2781642a38331a79f46f2e8f375cd442a#diff-b9cfc7f2cdf78a7f4b91a753d10865a2)
introduced some problems to the `package.json`, adding duplicate deps and re-adding the problematic github tarball dependency for @rase-'s fork of `xmlhttprequest`, as well as removing the dep for `component-inherit` used by the transport scripts.

I've reconstructed the package.json and rerun `make engine.io.js` so even the build of `engine.io.js` doesn't try to (de)require the wrong module.

Hopefully this can get patched quickly,
Thanks!