### PR TITLE
Remove iphone 4.3 for ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,13 +22,13 @@ matrix:
   - node_js: '0.10'
     env: BROWSER_NAME=ie BROWSER_VERSION=latest BROWSER_PLATFORM="Windows 2012"
   - node_js: '0.10'
-    env: BROWSER_NAME=iphone BROWSER_VERSION=4.3
-  - node_js: '0.10'
     env: BROWSER_NAME=iphone BROWSER_VERSION=5.1
   - node_js: '0.10'
     env: BROWSER_NAME=iphone BROWSER_VERSION=6.1
   - node_js: '0.10'
     env: BROWSER_NAME=iphone BROWSER_VERSION=7.1
+  - node_js: '0.10'
+    env: BROWSER_NAME=iphone BROWSER_VERSION=8.4
   - node_js: '0.10'
     env: BROWSER_NAME=android BROWSER_VERSION=4.0
   - node_js: '0.10'


### PR DESCRIPTION
It looks Sauce labs doesn't support ios 4.3 anymore. 
https://support.saucelabs.com/customer/portal/articles/2061176-end-of-life-for-osx-10-6-ios-4-3-ios-5-0-

I added ios 8.4 instead.

