### PR TITLE
update package dependency to support iojs 3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   ],
   "dependencies": {
     "has-cors": "1.1.0",
-    "ws": "0.7.2",
+    "ws": "0.8.0",
     "xmlhttprequest-ssl": "1.5.1",
     "component-emitter": "1.1.2",
     "indexof": "0.0.1",


### PR DESCRIPTION
updated dependency to use updated 'ws' that working with iojs 3.x buffers