### PR TITLE
transports: use `yeast` to generate the cache busting id

### DIFF
--- a/lib/transport.js
+++ b/lib/transport.js
@@ -51,13 +51,6 @@ function Transport (opts) {
 Emitter(Transport.prototype);
 
 /**
- * A counter used to prevent collisions in the timestamps used
- * for cache busting.
- */
-
-Transport.timestamps = 0;
-
-/**
  * Emits an error.
  *
  * @param {String} str

--- a/lib/transports/polling.js
+++ b/lib/transports/polling.js
@@ -6,6 +6,7 @@ var Transport = require('../transport');
 var parseqs = require('parseqs');
 var parser = require('engine.io-parser');
 var inherit = require('component-inherit');
+var yeast = require('yeast');
 var debug = require('debug')('engine.io-client:polling');
 
 /**
@@ -221,7 +222,7 @@ Polling.prototype.uri = function(){
 
   // cache busting is forced
   if (false !== this.timestampRequests) {
-    query[this.timestampParam] = +new Date + '-' + Transport.timestamps++;
+    query[this.timestampParam] = yeast();
   }
 
   if (!this.supportsBinary && !query.sid) {

--- a/lib/transports/websocket.js
+++ b/lib/transports/websocket.js
@@ -6,6 +6,7 @@ var Transport = require('../transport');
 var parser = require('engine.io-parser');
 var parseqs = require('parseqs');
 var inherit = require('component-inherit');
+var yeast = require('yeast');
 var debug = require('debug')('engine.io-client:websocket');
 
 /**
@@ -229,7 +230,7 @@ WS.prototype.uri = function(){
 
   // append timestamp to URI
   if (this.timestampRequests) {
-    query[this.timestampParam] = +new Date;
+    query[this.timestampParam] = yeast();
   }
 
   // communicate binary support capabilities

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "parseuri": "0.0.4",
     "parsejson": "0.0.1",
     "parseqs": "0.0.2",
-    "component-inherit": "0.0.3"
+    "component-inherit": "0.0.3",
+    "yeast": "0.1.2"
   },
   "devDependencies": {
     "blob": "0.0.2",

--- a/test/transport.js
+++ b/test/transport.js
@@ -114,7 +114,7 @@ describe('Transport', function () {
         , timestampParam: 't'
         , timestampRequests: true
       });
-      expect(polling.uri()).to.match(/http:\/\/localhost\/engine\.io\?(j=[0-9]+&)?(t=[0-9]+)/);
+      expect(polling.uri()).to.match(/http:\/\/localhost\/engine\.io\?(j=[0-9]+&)?(t=[0-9A-Za-z-_]+)/);
     });
 
     it('should generate a ws uri', function () {
@@ -146,7 +146,7 @@ describe('Transport', function () {
         , timestampParam: 'woot'
         , timestampRequests: true
       });
-      expect(ws.uri()).to.match(/ws:\/\/localhost\/engine\.io\?woot=[0-9]+/);
+      expect(ws.uri()).to.match(/ws:\/\/localhost\/engine\.io\?woot=[0-9A-Za-z-_]+/);
     });
   });
 


### PR DESCRIPTION
[`yeast`](https://github.com/unshiftio/yeast) is tiny unique ID generator specifically designed to generate IDs for cache busting.

The advantage of using it here is that the genrated ID is much smaller than the current one: 13 chars vs 7 chars.

The genrated ID is still a timestamp but represented as a string. Internally `yeast` works like [Number.prototype.toString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toString) returning a string representation of a given number (in our case the timestamp). This makes it possible to convert the string back to the original numerical value.