### PR TITLE
package: bump `zuul-ngrok`

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "istanbul": "0.2.3",
     "mocha": "1.16.2",
     "zuul": "1.17.1",
-    "zuul-ngrok": "2.0.0"
+    "zuul-ngrok": "3.1.0"
   },
   "scripts": {
     "test": "make test"


### PR DESCRIPTION
ngrok@0.1.98 install fails, also does 0.1.99
[Bump ngrok@0.2.1 by cristiandouce](https://github.com/rase-/zuul-ngrok/pull/6)