### PR TITLE
bump engine.io and fix a test

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "browserify": "6.2.0",
     "concat-stream": "1.4.6",
     "derequire": "1.2.0",
-    "engine.io": "socketio/engine.io#7e77dd5",
+    "engine.io": "socketio/engine.io#3df49bb",
     "expect.js": "0.2.0",
     "express": "3.4.8",
     "istanbul": "0.2.3",

--- a/test/connection.js
+++ b/test/connection.js
@@ -37,10 +37,10 @@ describe('connection', function() {
   it('should receive emoji', function(done) {
     var socket = new eio.Socket();
     socket.on('open', function () {
-      socket.send('\uD800-\uDB7F\uDB80-\uDBFF\uDC00-\uDFFF\uE000-\uF8FF');
+      socket.send('\uD800\uDC00-\uDB7F\uDFFF\uDB80\uDC00-\uDBFF\uDFFF\uE000-\uF8FF');
       socket.on('message', function (data) {
         if ('hi' == data) return;
-        expect(data).to.be('\uD800-\uDB7F\uDB80-\uDBFF\uDC00-\uDFFF\uE000-\uF8FF');
+        expect(data).to.be('\uD800\uDC00-\uDB7F\uDFFF\uDB80\uDC00-\uDBFF\uDFFF\uE000-\uF8FF');
         socket.close();
         done();
       });


### PR DESCRIPTION
For fixing the test, we have to use valid surrogate pairs since `utf8` module checks them now.

https://github.com/mathiasbynens/utf8.js/commit/728b895d986e6b62f8afbcbdee5323080d29a7da#diff-e82bcf432a71792a55fbe4e3904e6fbfR70