### PR TITLE
Revert "package: bump `zuul-ngrok`"

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "istanbul": "0.2.3",
     "mocha": "1.16.2",
     "zuul": "1.17.1",
-    "zuul-ngrok": "3.1.0"
+    "zuul-ngrok": "2.0.0"
   },
   "scripts": {
     "test": "make test"


### PR DESCRIPTION
Reverts socketio/engine.io-client#421

`ngrok@0.1.98`'s post-install file is restored. (I'm not sure.)
So [package: bump `zuul-ngrok`](https://github.com/socketio/engine.io-client/pull/421) is not necessary at present.

And this brings another issue

https://github.com/socketio/engine.io-client/pull/422
> ngrok v2.x requires sign up even though we set auth token.
