### PR TITLE
"long" and "short" are reserved javascript keywords

### DIFF
--- a/engine.io.js
+++ b/engine.io.js
@@ -2694,8 +2694,8 @@ module.exports = function(val, options){
   options = options || {};
   if ('string' == typeof val) return parse(val);
   return options.long
-    ? long(val)
-    : short(val);
+    ? longFormat(val)
+    : shortFormat(val);
 };
 
 /**
@@ -2745,7 +2745,7 @@ function parse(str) {
  * @api private
  */
 
-function short(ms) {
+function shortFormat(ms) {
   if (ms >= d) return Math.round(ms / d) + 'd';
   if (ms >= h) return Math.round(ms / h) + 'h';
   if (ms >= m) return Math.round(ms / m) + 'm';
@@ -2761,7 +2761,7 @@ function short(ms) {
  * @api private
  */
 
-function long(ms) {
+function longFormat(ms) {
   return plural(ms, d, 'day')
     || plural(ms, h, 'hour')
     || plural(ms, m, 'minute')


### PR DESCRIPTION
"long" and "short" are reserved javascript keywords according to the Google Javascript Closure Compiler.

This pull request enables engine.io.js to be compiled with the Google Closure Compiler.