### PR TITLE
Fix packet options

### DIFF
--- a/lib/transports/websocket.js
+++ b/lib/transports/websocket.js
@@ -171,7 +171,9 @@ WS.prototype.write = function(packets){
             // TypeError is thrown when passing the second argument on Safari
             self.ws.send(data);
           } else {
-            self.ws.send(data, packet.options);
+            self.ws.send(data, {
+                compress: packet.options.compress
+            });
           }
         } catch (e){
           debug('websocket closed before onclose event');


### PR DESCRIPTION
ws modifies the options object you pass to send(), so we need to make sure we don't give it an options object it already modified in a previous call. This can cause disconnections.