### PR TITLE
Fix syntax error on IE9 tests

### DIFF
--- a/test/engine.io-client.js
+++ b/test/engine.io-client.js
@@ -3,75 +3,58 @@ var expect = require('expect.js');
 var eio = require('../');
 
 describe('engine.io-client', function () {
+  var open;
+
+  before(function() {
+    open = eio.prototype.open;
+    // override Socket#open to not connect
+    eio.prototype.open = function() {};
+  });
+
+  after(function() {
+    eio.prototype.open = open;
+  });
 
   it('should expose protocol number', function () {
     expect(eio.protocol).to.be.a('number');
   });
 
-  it('should properly parse http uri without port', function(done) {
+  it('should properly parse http uri without port', function() {
     var client = eio('http://localhost');
-    client.on('close', function() {
-      done();
-    });
     expect(client.port).to.be('80');
-    client.close();
   });
 
-  it('should properly parse https uri without port', function(done) {
+  it('should properly parse https uri without port', function() {
     var client = eio('https://localhost');
-    client.on('close', function() {
-      done();
-    });
     expect(client.port).to.be('443');
-    client.close();
   });
 
-  it('should properly parse wss uri without port', function(done) {
+  it('should properly parse wss uri without port', function() {
     var client = eio('wss://localhost');
-    client.on('close', function() {
-      done();
-    });
     expect(client.port).to.be('443');
-    client.close();
   });
 
-  it('should properly parse wss uri with port', function(done) {
+  it('should properly parse wss uri with port', function() {
     var client = eio('wss://localhost:2020');
-    client.on('close', function() {
-      done();
-    });
     expect(client.port).to.be('2020');
-    client.close();
   });
 
-  it('should properly parse an IPv6 host without port (1/2)', function(done) {
+  it('should properly parse an IPv6 host without port (1/2)', function() {
     var client = eio({ host: '[::1]' });
-    client.on('close', function() {
-      done();
-    });
     expect(client.hostname).to.be('[::1]');
     expect(client.port).to.be('80');
-    client.close();
   });
 
-  it('should properly parse an IPv6 host without port (2/2)', function(done) {
+  it('should properly parse an IPv6 host without port (2/2)', function() {
     var client = eio({ secure: true, host: '[::1]:' });
-    client.on('close', function() {
-      done();
-    });
     expect(client.hostname).to.be('[::1]');
     expect(client.port).to.be('443');
-    client.close();
   });
 
-  it('should properly parse an IPv6 host with port', function(done) {
+  it('should properly parse an IPv6 host with port', function() {
     var client = eio({ host: '[::1]:8080' });
-    client.on('close', function() {
-      done();
-    });
     expect(client.hostname).to.be('[::1]');
     expect(client.port).to.be('8080');
-    client.close();
   });
 
 });

--- a/test/transport.js
+++ b/test/transport.js
@@ -10,12 +10,15 @@ describe('Transport', function () {
       var socket = new eio.Socket();
       expect(socket.transport.name).to.be('polling');
 
+      var timedout = false;
       var timeout = setTimeout(function(){
+        timedout = true;
         socket.close();
         done();
       }, 300);
 
       socket.on('upgrade', function (transport) {
+        if (timedout) return;
         clearTimeout(timeout);
         socket.close();
         if(transport.name == 'websocket') {
@@ -30,12 +33,15 @@ describe('Transport', function () {
       var socket = new eio.Socket();
       expect(socket.transport.name).to.be('polling');
 
+      var timedout = false;
       var timeout = setTimeout(function(){
+        timedout = true;
         socket.close();
         done();
       }, 300);
 
       socket.on('upgrade', function (transport) {
+        if (timedout) return;
         clearTimeout(timeout);
         socket.close();
         if(transport.name == 'websocket') {


### PR DESCRIPTION
On IE9, engine.io tries to connect with JSONP and throw `Syntax error` if the server url was invalid.
Additionally, I fixed the cases a few tests fail in a rase condition.