### PR TITLE
Fix typo

### DIFF
--- a/lib/transports/polling-xhr.js
+++ b/lib/transports/polling-xhr.js
@@ -351,7 +351,7 @@ Request.prototype.onLoad = function(){
         } catch (e) {
           var ui8Arr = new Uint8Array(this.xhr.response);
           var dataArray = [];
-          for (var idx = 0, length = ui8Arr.legnth; idx < length; idx++) {
+          for (var idx = 0, length = ui8Arr.length; idx < length; idx++) {
             dataArray.push(ui8Arr[idx]);
           }
 


### PR DESCRIPTION
https://github.com/socketio/engine.io-client/commit/d010541afd161ae417d30676d0be6286d70e9d1f#commitcomment-14678111

Fortunately, it seems this doesn't cause any errors, since the line is used only to get a response of write request. The response body is always just "[ok](https://github.com/socketio/engine.io/blob/master/lib/transports/polling.js#L186)". 