### PR TITLE
Threshold for permessage-deflate

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ Exposed as `eio` in the browser standalone build.
       - `rejectUnauthorized` (`Boolean`): If true, the server certificate is verified against the list of supplied CAs. An 'error' event is emitted if verification fails. Verification happens at the connection level, before the HTTP request is sent. Can be used in Node.js client environment to manually specify certificate information.
       - `perMessageDeflate` (`Object|Boolean`): parameters of the WebSocket permessage-deflate extension
         (see [ws module](https://github.com/einaros/ws) api docs). Set to `false` to disable. (`true`)
+        - `threshold` (`Number`): data is compressed only if the byte size is above this value. This option is ignored on the browser. (`1024`)
       - `extraHeaders` (`Object`): Headers that will be passed for each request to the server (via xhr-polling and via websockets). These values then can be used during handshake or for special proxies. Can only be used in Node.js client environment.
 - `send`
     - Sends a message to the server

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -299,7 +299,7 @@ Socket.prototype.probe = function (name) {
     if (failed) return;
 
     debug('probe transport "%s" opened', name);
-    transport.send([{ type: 'ping', data: 'probe', options: { compress: true } }]);
+    transport.send([{ type: 'ping', data: 'probe' }]);
     transport.once('packet', function (msg) {
       if (failed) return;
       if ('pong' == msg.type && 'probe' == msg.data) {
@@ -318,7 +318,7 @@ Socket.prototype.probe = function (name) {
           cleanup();
 
           self.setTransport(transport);
-          transport.send([{ type: 'upgrade', options: { compress: true } }]);
+          transport.send([{ type: 'upgrade' }]);
           self.emit('upgrade', transport);
           transport = null;
           self.upgrading = false;

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -95,7 +95,12 @@ function Socket(uri, opts){
   this.rememberUpgrade = opts.rememberUpgrade || false;
   this.binaryType = null;
   this.onlyBinaryUpgrades = opts.onlyBinaryUpgrades;
-  this.perMessageDeflate = false !== opts.perMessageDeflate ? (opts.perMessageDeflate || true) : false;
+  this.perMessageDeflate = false !== opts.perMessageDeflate ? (opts.perMessageDeflate || {}) : false;
+
+  if (true === this.perMessageDeflate) this.perMessageDeflate = {};
+  if (this.perMessageDeflate && null == this.perMessageDeflate.threshold) {
+    this.perMessageDeflate.threshold = 1024;
+  }
 
   // SSL options for Node.js client
   this.pfx = opts.pfx || null;

--- a/lib/transports/websocket.js
+++ b/lib/transports/websocket.js
@@ -157,7 +157,7 @@ WS.prototype.write = function(packets){
   var self = this;
   this.writable = false;
 
-  var isBrowserWebSocket = global.WebSocket && this.ws instanceof global.WebSocket
+  var isBrowserWebSocket = global.WebSocket && this.ws instanceof global.WebSocket;
 
   // encodePacket efficient as it uses WS framing
   // no need for encodePayload
@@ -173,7 +173,7 @@ WS.prototype.write = function(packets){
           }
 
           if (self.perMessageDeflate) {
-            var len = 'string' == typeof data ? Buffer.byteLength(data) : data.length;
+            var len = 'string' == typeof data ? global.Buffer.byteLength(data) : data.length;
             if (len < self.perMessageDeflate.threshold) {
               opts.compress = false;
             }

--- a/lib/transports/websocket.js
+++ b/lib/transports/websocket.js
@@ -157,23 +157,38 @@ WS.prototype.write = function(packets){
   var self = this;
   this.writable = false;
 
+  var isBrowserWebSocket = global.WebSocket && this.ws instanceof global.WebSocket
+
   // encodePacket efficient as it uses WS framing
   // no need for encodePayload
   var total = packets.length;
   for (var i = 0, l = total; i < l; i++) {
     (function(packet) {
       parser.encodePacket(packet, self.supportsBinary, function(data) {
+        if (!isBrowserWebSocket) {
+          // always create a new object (GH-437)
+          var opts = {};
+          if (packet.options) {
+            opts.compress = packet.options.compress;
+          }
+
+          if (self.perMessageDeflate) {
+            var len = 'string' == typeof data ? Buffer.byteLength(data) : data.length;
+            if (len < self.perMessageDeflate.threshold) {
+              opts.compress = false;
+            }
+          }
+        }
+
         //Sometimes the websocket has already been closed but the browser didn't
         //have a chance of informing us about it yet, in that case send will
         //throw an error
         try {
-          if (global.WebSocket && self.ws instanceof global.WebSocket) {
+          if (isBrowserWebSocket) {
             // TypeError is thrown when passing the second argument on Safari
             self.ws.send(data);
           } else {
-            self.ws.send(data, {
-                compress: packet.options.compress
-            });
+            self.ws.send(data, opts);
           }
         } catch (e){
           debug('websocket closed before onclose event');

--- a/test/transport.js
+++ b/test/transport.js
@@ -210,6 +210,42 @@ if (!env.browser) {
         expect(polling.extraHeaders).to.equal(headers);
       });
     });
+
+    describe('perMessageDeflate', function () {
+      it('should set threshold', function (done) {
+        var socket = new eio.Socket({ transports: ['websocket'], perMessageDeflate: { threshold: 0 } });
+        socket.on('open', function() {
+          var ws = socket.transport.ws;
+          var send = ws.send;
+          ws.send = function(data, opts, callback) {
+            ws.send = send;
+            ws.send(data, opts, callback);
+
+            expect(opts.compress).to.be(true);
+            socket.close();
+            done();
+          };
+          socket.send('hi', { compress: true });
+        });
+      });
+
+      it('should not compress when the byte size is below threshold', function (done) {
+        var socket = new eio.Socket({ transports: ['websocket'] });
+        socket.on('open', function() {
+          var ws = socket.transport.ws;
+          var send = ws.send;
+          ws.send = function(data, opts, callback) {
+            ws.send = send;
+            ws.send(data, opts, callback);
+
+            expect(opts.compress).to.be(false);
+            socket.close();
+            done();
+          };
+          socket.send('hi', { compress: true });
+        });
+      });
+    });
   });
 }
 


### PR DESCRIPTION
This PR adds the threshold option to perMessageDeflate for filtering data.

Related: https://github.com/socketio/engine.io/pull/369