### PR TITLE
Prevent ws from being added to the bundle

### DIFF
--- a/.zuul.yml
+++ b/.zuul.yml
@@ -4,5 +4,3 @@ tunnel:
   type: ngrok
   authtoken: 6Aw8vTgcG5EvXdQywVvbh_3fMxvd4Q7dcL2caAHAFjV
   proto: tcp
-browserify:
-  - exclude: ws

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Engine.IO is a commonjs module, which means you can include it by using
 1. build your app bundle
 
     ```bash
-    $ browserify app.js -i ws > bundle.js
+    $ browserify app.js > bundle.js
     ```
 
 1. include on your page

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "test": "make test"
   },
   "browser": {
+    "ws": false,
     "xmlhttprequest-ssl": "./lib/xmlhttprequest.js"
   },
   "repository": {

--- a/support/browserify.js
+++ b/support/browserify.js
@@ -28,7 +28,6 @@ function build(fn){
     insertGlobalVars: { global: glob },
     standalone: 'eio'
   })
-  .exclude('ws')
   .bundle();
 
   bundle.on('error', function (err) {


### PR DESCRIPTION
As documented [there](https://github.com/defunctzombie/package-browser-field-spec/blob/master/README.md#ignore-a-module), this should (finally) fix issues with `ws`.

Related:
- https://github.com/socketio/engine.io-client/issues/450
- https://github.com/socketio/socket.io-client/issues/933