### PR TITLE
Safely resolve `ws` module.

### DIFF
--- a/lib/transports/websocket.js
+++ b/lib/transports/websocket.js
@@ -12,11 +12,16 @@ var BrowserWebSocket = global.WebSocket || global.MozWebSocket;
 
 /**
  * Get either the `WebSocket` or `MozWebSocket` globals
- * in the browser or the WebSocket-compatible interface
- * exposed by `ws` for Node environment.
+ * in the browser or try to resolve WebSocket-compatible
+ * interface exposed by `ws` for Node-like environment.
  */
 
-var WebSocket = BrowserWebSocket || (typeof window !== 'undefined' ? null : require('ws'));
+var WebSocket = BrowserWebSocket;
+if (!WebSocket && typeof window === 'undefined') {
+  try {
+    WebSocket = require('ws');
+  } catch (e) { }
+}
 
 /**
  * Module exports.


### PR DESCRIPTION
After changing the `ws` dependency to be ignored, not exluded, by https://github.com/socketio/engine.io-client/pull/451 if the target runtime does not provide a `ws` module an error is throw. This is the case with NativeScript which currently does not have a WebSocket implementation. The change is using safe resolution with try-catch preseving the old behavior in a controlled manner.