### PR TITLE
Enable definition of timeouts for xhr-polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Exposed as `eio` in the browser standalone build.
     - `String` | `ArrayBuffer`: utf-8 encoded data or ArrayBuffer containing
       binary data
 - `close`
-  - Fired upon disconnection. In compliance with the WebSocket API spec, this event may be 
+  - Fired upon disconnection. In compliance with the WebSocket API spec, this event may be
     fired even if the `open` event does not occur (i.e. due to connection error or `close()`).
 - `error`
   - Fired when an error occurs.
@@ -223,6 +223,7 @@ Exposed as `eio` in the browser standalone build.
         (see [ws module](https://github.com/einaros/ws) api docs). Set to `false` to disable. (`true`)
         - `threshold` (`Number`): data is compressed only if the byte size is above this value. This option is ignored on the browser. (`1024`)
       - `extraHeaders` (`Object`): Headers that will be passed for each request to the server (via xhr-polling and via websockets). These values then can be used during handshake or for special proxies. Can only be used in Node.js client environment.
+      - `requestTimeout` (`Number`): Timeout for xhr-polling requests in milliseconds, defaults to no timeout.
 - `send`
     - Sends a message to the server
     - **Parameters**
@@ -289,4 +290,3 @@ See the `Tests` section above for how to run tests before submitting any patches
 ## License
 
 MIT - Copyright (c) 2014 Automattic, Inc.
-

--- a/lib/transports/polling-xhr.js
+++ b/lib/transports/polling-xhr.js
@@ -30,6 +30,7 @@ function empty(){}
 
 function XHR(opts){
   Polling.call(this, opts);
+  this.requestTimeout = opts.requestTimeout;
 
   if (global.location) {
     var isSSL = 'https:' == location.protocol;
@@ -84,6 +85,7 @@ XHR.prototype.request = function(opts){
   opts.ca = this.ca;
   opts.ciphers = this.ciphers;
   opts.rejectUnauthorized = this.rejectUnauthorized;
+  opts.requestTimeout = this.requestTimeout;
 
   // other options for Node.js client
   opts.extraHeaders = this.extraHeaders;
@@ -147,6 +149,7 @@ function Request(opts){
   this.isBinary = opts.isBinary;
   this.supportsBinary = opts.supportsBinary;
   this.enablesXDR = opts.enablesXDR;
+  this.requestTimeout = opts.requestTimeout;
 
   // SSL options for Node.js client
   this.pfx = opts.pfx;
@@ -222,6 +225,10 @@ Request.prototype.create = function(){
     // ie6 check
     if ('withCredentials' in xhr) {
       xhr.withCredentials = true;
+    }
+
+    if (this.requestTimeout) {
+      xhr.timeout = this.requestTimeout;
     }
 
     if (this.hasXDR()) {


### PR DESCRIPTION
The definition of timeouts is desirable to cancel long outstanding
requests automatically via browser mechanisms. Specifically, it can
happen that lots of pending XHR requests are scheduled, but are never
purged by the browser due to the lack of a timeout definition.
