### PR TITLE
Gulpfile refactoring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,4 @@
 
-REPORTER = dot
-
 build: engine.io.js
 
 engine.io.js:

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -113,10 +113,12 @@ gulp.task('test-cov', ['istanbul-pre-test'], function () {
     .pipe(mocha(MOCHA_OPTS))
     .pipe(istanbul.writeReports())
     .once('error', function (err) {
+      cleanFiles(FILES_TO_CLEAN);
       console.error(err.stack);
       process.exit(1);
     })
     .once('end', function () {
+      cleanFiles(FILES_TO_CLEAN);
       process.exit();
     });
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -18,9 +18,7 @@ const BUILD_TARGET_DIR = './';
 gulp.task('default', ['build']);
 
 gulp.task('build', function () {
-  return gulp.src(['lib/*.js', 'lib/transports/*.js'], {
-    base: 'lib'
-  })
+  return gulp.src('lib/**/*.js')
     .pipe(webpack(require('./support/webpack.config.js')))
     .pipe(gulp.dest(BUILD_TARGET_DIR));
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -27,9 +27,12 @@ gulp.task('build', function () {
 // TESTING
 // //////////////////////////////////////
 
-const REPORTER = 'dot';
 const TEST_FILE = './test/index.js';
-const TEST_SUPPORT_SERVER_FILE = './test/support/server.js';
+const MOCHA_OPTS = {
+  reporter: 'dot',
+  require: ['./test/support/server.js'],
+  bail: true
+};
 const FILES_TO_CLEAN = [
   'test/support/public/engine.io.js'
 ];
@@ -58,11 +61,6 @@ gulp.task('test-node', testNode);
 gulp.task('test-zuul', testZuul);
 
 function testNode () {
-  const MOCHA_OPTS = {
-    reporter: REPORTER,
-    require: [TEST_SUPPORT_SERVER_FILE],
-    bail: true
-  };
   return gulp.src(TEST_FILE, { read: false })
     .pipe(mocha(MOCHA_OPTS))
     // following lines to fix gulp-mocha not terminating (see gulp-mocha webpage)
@@ -112,9 +110,7 @@ gulp.task('istanbul-pre-test', function () {
 
 gulp.task('test-cov', ['istanbul-pre-test'], function () {
   return gulp.src(['test/*.js', 'test/support/*.js'])
-    .pipe(mocha({
-      reporter: REPORTER
-    }))
+    .pipe(mocha(MOCHA_OPTS))
     .pipe(istanbul.writeReports())
     .once('error', function (err) {
       console.error(err.stack);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -109,7 +109,7 @@ gulp.task('istanbul-pre-test', function () {
 });
 
 gulp.task('test-cov', ['istanbul-pre-test'], function () {
-  return gulp.src(['test/*.js', 'test/support/*.js'])
+  return gulp.src(TEST_FILE)
     .pipe(mocha(MOCHA_OPTS))
     .pipe(istanbul.writeReports())
     .once('error', function (err) {


### PR DESCRIPTION
- Use `lib/**/*.js` for `gulp build` as suggested in https://github.com/socketio/engine.io-client/pull/455/files#diff-b9e12334e9eafd8341a6107dd98510c9R22
- Refactor `MOCHA_OPTS` out of test-node so that it can be used by test-cov as well
- Clean generated file after test-cov