### PR TITLE
bump zuul

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "mocha": "1.16.2",
     "webpack": "1.12.12",
     "webpack-stream": "3.1.0",
-    "zuul": "3.7.2",
+    "zuul": "3.10.1",
     "zuul-builder-webpack": "1.1.0",
     "zuul-ngrok": "3.2.0"
   },


### PR DESCRIPTION
It seems updating zuul is required for running tests on iOS  7.1.