### PR TITLE
Remove a workaround for old iOS

### DIFF
--- a/lib/transports/websocket.js
+++ b/lib/transports/websocket.js
@@ -136,23 +136,6 @@ WS.prototype.addEventListeners = function () {
 };
 
 /**
- * Override `onData` to use a timer on iOS.
- * See: https://gist.github.com/mloughran/2052006
- *
- * @api private
- */
-
-if ('undefined' !== typeof navigator &&
-  /iPad|iPhone|iPod/i.test(navigator.userAgent)) {
-  WS.prototype.onData = function (data) {
-    var self = this;
-    setTimeout(function () {
-      Transport.prototype.onData.call(self, data);
-    }, 0);
-  };
-}
-
-/**
  * Writes data to socket.
  *
  * @param {Array} array of packets.


### PR DESCRIPTION
Fix https://github.com/socketio/engine.io-client/issues/462

It'd be arguable but I think we can remove the workaround for old iOS.
The original bug has already been fixed in years ago: https://bugs.webkit.org/show_bug.cgi?id=81517 