### PR TITLE
More-specific imports for browser-based module loaders

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,2 +1,2 @@
 
-module.exports = require('./lib/');
+module.exports = require('./lib/index');

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -2,7 +2,7 @@
  * Module dependencies.
  */
 
-var transports = require('./transports');
+var transports = require('./transports/index');
 var Emitter = require('component-emitter');
 var debug = require('debug')('engine.io-client:socket');
 var index = require('indexof');
@@ -126,7 +126,7 @@ Socket.protocol = parser.protocol; // this is an int
 
 Socket.Socket = Socket;
 Socket.Transport = require('./transport');
-Socket.transports = require('./transports');
+Socket.transports = require('./transports/index');
 Socket.parser = require('engine.io-parser');
 
 /**


### PR DESCRIPTION
This allows browser loaders like StealJS to load this package (since you the only way to check if a file exists from the browser it to request it, node-style folder assumptions can't be made without potential 404s.)

The package works fine with the StealJS build tools, since they're node based, but this allows it to work with the browser version.