### PR TITLE
Adds forceNode flag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,8 @@ Exposed as `eio` in the browser standalone build.
         (see [ws module](https://github.com/einaros/ws) api docs). Set to `false` to disable. (`true`)
         - `threshold` (`Number`): data is compressed only if the byte size is above this value. This option is ignored on the browser. (`1024`)
       - `extraHeaders` (`Object`): Headers that will be passed for each request to the server (via xhr-polling and via websockets). These values then can be used during handshake or for special proxies. Can only be used in Node.js client environment.
+      - `forceNode` (`Boolean`): defaults to `false` (NodeJS only). 
+        Uses NodeJS implementation for websockets - even if there is a native Browser-Websocket available, which is preferred by default over the NodeJS implementation. (This is useful when using hybrid platforms like nw.js or electron)
 - `send`
     - Sends a message to the server
     - **Parameters**

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -91,6 +91,7 @@ function Socket (uri, opts) {
   this.ca = opts.ca || null;
   this.ciphers = opts.ciphers || null;
   this.rejectUnauthorized = opts.rejectUnauthorized === undefined ? true : opts.rejectUnauthorized;
+  this.forceNode = !!opts.forceNode;
 
   // other options for Node.js client
   var freeGlobal = typeof global === 'object' && global;
@@ -173,7 +174,8 @@ Socket.prototype.createTransport = function (name) {
     ciphers: this.ciphers,
     rejectUnauthorized: this.rejectUnauthorized,
     perMessageDeflate: this.perMessageDeflate,
-    extraHeaders: this.extraHeaders
+    extraHeaders: this.extraHeaders,
+    forceNode: this.forceNode
   });
 
   return transport;

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -39,6 +39,7 @@ function Transport (opts) {
   this.ca = opts.ca;
   this.ciphers = opts.ciphers;
   this.rejectUnauthorized = opts.rejectUnauthorized;
+  this.forceNode = opts.forceNode;
 
   // other options for Node.js client
   this.extraHeaders = opts.extraHeaders;

--- a/lib/transports/websocket.js
+++ b/lib/transports/websocket.js
@@ -9,18 +9,22 @@ var inherit = require('component-inherit');
 var yeast = require('yeast');
 var debug = require('debug')('engine.io-client:websocket');
 var BrowserWebSocket = global.WebSocket || global.MozWebSocket;
+var NodeWebSocket;
+try {
+  NodeWebSocket = require('ws');
+} catch (e) { }
 
 /**
  * Get either the `WebSocket` or `MozWebSocket` globals
  * in the browser or try to resolve WebSocket-compatible
  * interface exposed by `ws` for Node-like environment.
+ *
+ * This behavior can be overwritten by the forceNode- flag.
+ * This flag will be checked on opening the connection. See WS.doOpen.
  */
-
 var WebSocket = BrowserWebSocket;
 if (!WebSocket && typeof window === 'undefined') {
-  try {
-    WebSocket = require('ws');
-  } catch (e) { }
+  WebSocket = NodeWebSocket;
 }
 
 /**
@@ -96,7 +100,8 @@ WS.prototype.doOpen = function () {
     opts.headers = this.extraHeaders;
   }
 
-  this.ws = BrowserWebSocket ? new WebSocket(uri) : new WebSocket(uri, protocols, opts);
+  var Socket = this.forceNode ? NodeWebSocket : WebSocket;
+  this.ws = BrowserWebSocket && !this.forceNode ? new Socket(uri) : new Socket(uri, protocols, opts);
 
   if (this.ws.binaryType === undefined) {
     this.supportsBinary = false;


### PR DESCRIPTION
As discussed in #461, I created a pull request with an (optional) flag that changes the preference of native Websockets over the nodejs implementation.
To ensure compatibility the default behavior - by setting forceNode to false or by not setting it at all - does not change.

I just adjusted it for the websocket-transport as the others already have the correct behavior. (Should this be mentioned in the documentation?)
