### PR TITLE
Add support for per transport options

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -137,14 +137,15 @@ Socket.parser = require('engine.io-parser');
  * @api private
  */
 
-Socket.prototype.createTransport = function (transport) {
-  var name, options = {};
+Socket.prototype.createTransport = function (transporter) {
+  var name;
+  var transportOptions = {};
 
-  if (transport.options) {
-    name = transport.name;
-    options = transport.options;
+  if (transporter.transportOptions) {
+    name = transporter.name;
+    transportOptions = transporter.transportOptions;
   } else {
-    name = transport;
+    name = transporter;
   }
 
   debug('creating transport "%s"', name);
@@ -161,10 +162,10 @@ Socket.prototype.createTransport = function (transport) {
 
   var transport = new transports[name]({
     agent: this.agent,
-    hostname: options.hostname || this.hostname,
-    port: options.port || this.port,
-    secure: options.secure || this.secure,
-    path: options.path || this.path,
+    hostname: transportOptions.hostname || this.hostname,
+    port: transportOptions.port || this.port,
+    secure: transportOptions.secure || this.secure,
+    path: transportOptions.path || this.path,
     query: query,
     forceJSONP: this.forceJSONP,
     jsonp: this.jsonp,

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -137,7 +137,16 @@ Socket.parser = require('engine.io-parser');
  * @api private
  */
 
-Socket.prototype.createTransport = function (name) {
+Socket.prototype.createTransport = function (transport) {
+  var name, options = {};
+
+  if (transport.options) {
+    name = transport.name;
+    options = transport.options;
+  } else {
+    name = transport;
+  }
+
   debug('creating transport "%s"', name);
   var query = clone(this.query);
 
@@ -152,10 +161,10 @@ Socket.prototype.createTransport = function (name) {
 
   var transport = new transports[name]({
     agent: this.agent,
-    hostname: this.hostname,
-    port: this.port,
-    secure: this.secure,
-    path: this.path,
+    hostname: options.hostname || this.hostname,
+    port: options.port || this.port,
+    secure: options.secure || this.secure,
+    path: options.path || this.path,
     query: query,
     forceJSONP: this.forceJSONP,
     jsonp: this.jsonp,


### PR DESCRIPTION
sometimes we need different transports to go to different destinations.

For example, when doing ELB load balancing, ELB can't do both websockets (TCP) and HTTP affinity (which is needed for polling) unless we use different ports.

With this simple solution socket.io can now easily work with ELB.

[Checkout this PR for full description](https://github.com/socketio/socket.io-client/pull/907)
