### PR TITLE
use xhr.responseText if xhr.response is not provided

### DIFF
--- a/lib/transports/polling-xhr.js
+++ b/lib/transports/polling-xhr.js
@@ -341,7 +341,7 @@ Request.prototype.onLoad = function () {
       contentType = this.xhr.getResponseHeader('Content-Type').split(';')[0];
     } catch (e) {}
     if (contentType === 'application/octet-stream') {
-      data = this.xhr.response;
+      data = this.xhr.response || this.xhr.responseText;
     } else {
       if (!this.supportsBinary) {
         data = this.xhr.responseText;


### PR DESCRIPTION
This simple fix addresses a compatibility issue with package xmlhttprequest-ssl. The problem is that this package always puts the response to a request in the `responseText` field of the xhr object, even when the server provides a binary response, which should be exposed in the `response` field instead.

This fix just makes sure if `response` isn't set, then `responseText` is used. Let me know what you think. We could fix the dependent package, but that is a fork of a fork of the original project, and does not look to be very active.

I have verified this fix using this client against my Python based Flask-SocketIO server. The problem was reported to me in https://github.com/miguelgrinberg/Flask-SocketIO/issues/253.