### PR TITLE
onPacket now emits data on 'closing' state as well

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -404,7 +404,8 @@ Socket.prototype.onOpen = function () {
  */
 
 Socket.prototype.onPacket = function (packet) {
-  if ('opening' === this.readyState || 'open' === this.readyState) {
+  if ('opening' === this.readyState || 'open' === this.readyState ||
+      'closing' === this.readyState) {
     debug('socket receive: type "%s", data "%s"', packet.type, packet.data);
 
     this.emit('packet', packet);


### PR DESCRIPTION
The issue: when calling socket.disconnet() the socket would not close as
onPacket() would not process data from writeBuffer. The reason for this was
because the close() function was setting the readyState to 'closing'. The
onPacket() was getting executed but it only emits the packet if the readyState
is set to 'open' or 'opening', otherwise it won't do anything. In this case the
onPacket() was repeatedly executed to emit packets and it was causing the
socket to hang and never close. This would lead to infinite attempts to send
the data from writeBuffer and the socket was never being closed.

To fix this issue I updated onPacket() to emit packets on the 'closing' state
as well. Now the writeBuffer will be drained on 'closing' state and the socket
can be closed.