### PR TITLE
Update ws package which has a CVE

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,3 +44,5 @@ matrix:
     env: BROWSER_NAME=android BROWSER_VERSION=4.3
   - node_js: '0.10'
     env: BROWSER_NAME=android BROWSER_VERSION=4.4
+after_script:
+  - npm run scan_packages

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Exposed as `eio` in the browser standalone build.
     - `String` | `ArrayBuffer`: utf-8 encoded data or ArrayBuffer containing
       binary data
 - `close`
-  - Fired upon disconnection. In compliance with the WebSocket API spec, this event may be 
+  - Fired upon disconnection. In compliance with the WebSocket API spec, this event may be
     fired even if the `open` event does not occur (i.e. due to connection error or `close()`).
 - `error`
   - Fired when an error occurs.
@@ -258,8 +258,9 @@ run the tests locally using the following command.
 ```
 
 Additionally, `engine.io-client` has a standalone test suite you can run
-with `make test` which will run node.js and browser tests. You must have zuul setup with
-a saucelabs account.
+with `make test` which will run node.js and browser tests. You must have zuul setup with a saucelabs account.
+
+It is also good practice to check for CVEs if any of the dependencies change. To do this use `npm run scan_packages`.
 
 ## Support
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "parsejson": "0.0.1",
     "parseqs": "0.0.2",
     "parseuri": "0.0.4",
-    "ws": "1.0.1",
+    "ws": "1.1.1",
     "xmlhttprequest-ssl": "1.5.1",
     "yeast": "0.1.2"
   },
@@ -45,9 +45,9 @@
     "concat-stream": "1.4.6",
     "del": "2.2.0",
     "derequire": "1.2.0",
+    "engine.io": "1.6.11",
     "eslint-config-standard": "4.4.0",
     "eslint-plugin-standard": "1.3.1",
-    "engine.io": "1.6.11",
     "expect.js": "0.2.0",
     "express": "3.4.8",
     "gulp": "3.9.0",
@@ -58,6 +58,7 @@
     "gulp-task-listing": "1.0.1",
     "istanbul": "0.2.3",
     "mocha": "1.16.2",
+    "nsp": "^2.6.1",
     "webpack": "1.12.12",
     "webpack-stream": "3.1.0",
     "zuul": "3.7.2",
@@ -65,7 +66,8 @@
     "zuul-ngrok": "3.2.0"
   },
   "scripts": {
-    "test": "gulp test"
+    "test": "gulp test",
+    "scan_packages": "nsp check --output summary"
   },
   "browser": {
     "ws": false,


### PR DESCRIPTION
The ws node package has [a CVE](https://nodesecurity.io/advisories/120).
Upgrading to `1.1.1` will include the patch.

Also updated README to include documentation on checking for CVEs and
`.travis.yml` file so check for CVEs on each build.