### PR TITLE
Define "requestsCount" var and "requests" hash unconditionally

### DIFF
--- a/lib/transports/polling-xhr.js
+++ b/lib/transports/polling-xhr.js
@@ -393,9 +393,10 @@ Request.prototype.abort = function () {
  * emitted.
  */
 
+Request.requestsCount = 0;
+Request.requests = {};
+
 if (global.document) {
-  Request.requestsCount = 0;
-  Request.requests = {};
   if (global.attachEvent) {
     global.attachEvent('onunload', unloadHandler);
   } else if (global.addEventListener) {


### PR DESCRIPTION
There are situations in which `global.document` can be defined after the file is loaded, but before a request is created. This kills `Request.prototype.create` here:

```js
  if (global.document) {
    this.index = Request.requestsCount++;
    Request.requests[this.index] = this;
  }
```

As the global exists, but those static properties were never defined. Is there any harm in defining them unconditionally?