### PR TITLE
Bumping version due to newer package dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "engine.io-client",
   "description": "Client for the realtime Engine",
   "license": "MIT",
-  "version": "1.6.11",
+  "version": "1.6.12",
   "homepage": "https://github.com/socketio/engine.io-client",
   "contributors": [
     {


### PR DESCRIPTION
Also required to publish a new npm package to resolve the problem with the 1.6.11 version using an old and insecure `ws` package dependency.