### PR TITLE
[chore] Restrict files included in npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,0 @@
-support/
-test

--- a/package.json
+++ b/package.json
@@ -74,5 +74,10 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/socketio/engine.io-client.git"
-  }
+  },
+  "files": [
+    "index.js",
+    "lib/",
+    "engine.io.js"
+  ]
 }


### PR DESCRIPTION
Note: I left `engine.io.js` file, since it was included in previous releases, but that may not be useful.