### PR TITLE
Obfuscate `ActiveXObject` occurrences

### DIFF
--- a/lib/xmlhttprequest.js
+++ b/lib/xmlhttprequest.js
@@ -1,8 +1,5 @@
 // browser shim for xmlhttprequest module
 
-// Indicate to eslint that ActiveXObject is global
-/* global ActiveXObject */
-
 var hasCORS = require('has-cors');
 
 module.exports = function (opts) {
@@ -34,7 +31,7 @@ module.exports = function (opts) {
 
   if (!xdomain) {
     try {
-      return new ActiveXObject('Microsoft.XMLHTTP');
+      return new global[['Active'].concat('Object').join('X')]('Microsoft.XMLHTTP');
     } catch (e) { }
   }
 };


### PR DESCRIPTION
Some corporate firewalls/proxies such as Blue Coat prevent JavaScript files from being downloaded if they contain the word "ActiveX".

The proposed change is based on [`node-active-x-obfuscator`](https://github.com/felixge/node-active-x-obfuscator).

With #465 merged it would be nice if we could remove another floating [patch](https://github.com/primus/primus/blob/master/transformers/engine.io/patches/activex.patch) from Primus.