### PR TITLE
Fixed regression creating connection over https from node

### DIFF
--- a/lib/transports/polling.js
+++ b/lib/transports/polling.js
@@ -230,8 +230,8 @@ Polling.prototype.uri = function () {
   query = parseqs.encode(query);
 
   // avoid port if default for schema
-  if (this.port && (('https' === schema && this.port !== 443) ||
-     ('http' === schema && this.port !== 80))) {
+  if (this.port && (('https' === schema && Number(this.port) !== 443) ||
+     ('http' === schema && Number(this.port) !== 80))) {
     port = ':' + this.port;
   }
 


### PR DESCRIPTION
Fixes regression from #fd90acf4 in which establishing connection over https failed with error visible to socket.io-client as `reconnect_error` with Error object:` {"type":"TransportError","description":404}`


### The kind of change this PR does introduce

* [x] a bug fix



