### PR TITLE
Speed up lint by avoiding '**/*.js' matching pattern

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -47,9 +47,9 @@ gulp.task('test', ['lint'], function () {
 
 gulp.task('lint', function () {
   return gulp.src([
-    '**/*.js',
-    '!node_modules/**',
-    '!coverage/**',
+    '*.js',
+    'lib/**/*.js',
+    'test/**/*.js',
     '!engine.io.js'
   ])
     .pipe(eslint())

--- a/test/support/public/worker.js
+++ b/test/support/public/worker.js
@@ -1,4 +1,4 @@
-/*global importScripts,eio,postMessage*/
+/* global importScripts,eio,postMessage */
 
 importScripts('/test/support/engine.io.js');
 


### PR DESCRIPTION
Before:

```
[02:01:45] Using gulpfile ~/git/engine.io-client/gulpfile.js
[02:01:45] Starting 'lint'...
[02:02:07] Finished 'lint' after 22 s
[02:02:07] Starting 'test'...
```

After:

```
[02:02:34] Using gulpfile ~/git/engine.io-client/gulpfile.js
[02:02:34] Starting 'lint'...
[02:02:36] Finished 'lint' after 2.67 s
[02:02:36] Starting 'test'...
```
