### PR TITLE
Add support for per transport options

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ Exposed as `eio` in the browser standalone build.
       Defaults to `['polling', 'websocket']`. `Engine`
       always attempts to connect directly with the first one, provided the
       feature detection test for it passes.
+      - `transportOptions` (`Object`): hash of options, indexed by transport name, overriding the common options for the given transport
       - `rememberUpgrade` (`Boolean`): defaults to false.
         If true and if the previous websocket connection to the server succeeded,
         the connection attempt will bypass the normal upgrade process and will initially

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -70,6 +70,7 @@ function Socket (uri, opts) {
   this.timestampParam = opts.timestampParam || 't';
   this.timestampRequests = opts.timestampRequests;
   this.transports = opts.transports || ['polling', 'websocket'];
+  this.transportOptions = opts.transportOptions || {};
   this.readyState = '';
   this.writeBuffer = [];
   this.prevBufferLen = 0;
@@ -163,35 +164,38 @@ Socket.prototype.createTransport = function (name) {
   // transport name
   query.transport = name;
 
+  // per-transport options
+  var options = this.transportOptions[name] || {};
+
   // session id if we already have one
   if (this.id) query.sid = this.id;
 
   var transport = new transports[name]({
-    agent: this.agent,
-    hostname: this.hostname,
-    port: this.port,
-    secure: this.secure,
-    path: this.path,
+    agent: options.agent || this.agent,
+    hostname: options.hostname || this.hostname,
+    port: options.port || this.port,
+    secure: options.secure || this.secure,
+    path: options.path || this.path,
     query: query,
-    forceJSONP: this.forceJSONP,
-    jsonp: this.jsonp,
-    forceBase64: this.forceBase64,
-    enablesXDR: this.enablesXDR,
-    timestampRequests: this.timestampRequests,
-    timestampParam: this.timestampParam,
-    policyPort: this.policyPort,
+    forceJSONP: options.forceJSONP || this.forceJSONP,
+    jsonp: options.jsonp || this.jsonp,
+    forceBase64: options.forceBase64 || this.forceBase64,
+    enablesXDR: options.enablesXDR || this.enablesXDR,
+    timestampRequests: options.timestampRequests || this.timestampRequests,
+    timestampParam: options.timestampParam || this.timestampParam,
+    policyPort: options.policyPort || this.policyPort,
     socket: this,
-    pfx: this.pfx,
-    key: this.key,
-    passphrase: this.passphrase,
-    cert: this.cert,
-    ca: this.ca,
-    ciphers: this.ciphers,
-    rejectUnauthorized: this.rejectUnauthorized,
-    perMessageDeflate: this.perMessageDeflate,
-    extraHeaders: this.extraHeaders,
-    forceNode: this.forceNode,
-    localAddress: this.localAddress
+    pfx: options.pfx || this.pfx,
+    key: options.key || this.key,
+    passphrase: options.passphrase || this.passphrase,
+    cert: options.cert || this.cert,
+    ca: options.ca || this.ca,
+    ciphers: options.ciphers || this.ciphers,
+    rejectUnauthorized: options.rejectUnauthorized || this.rejectUnauthorized,
+    perMessageDeflate: options.perMessageDeflate || this.perMessageDeflate,
+    extraHeaders: options.extraHeaders || this.extraHeaders,
+    forceNode: options.forceNode || this.forceNode,
+    localAddress: options.localAddress || this.localAddress
   });
 
   return transport;

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -171,12 +171,13 @@ Socket.prototype.createTransport = function (name) {
   if (this.id) query.sid = this.id;
 
   var transport = new transports[name]({
+    query: query,
+    socket: this,
     agent: options.agent || this.agent,
     hostname: options.hostname || this.hostname,
     port: options.port || this.port,
     secure: options.secure || this.secure,
     path: options.path || this.path,
-    query: query,
     forceJSONP: options.forceJSONP || this.forceJSONP,
     jsonp: options.jsonp || this.jsonp,
     forceBase64: options.forceBase64 || this.forceBase64,
@@ -184,7 +185,6 @@ Socket.prototype.createTransport = function (name) {
     timestampRequests: options.timestampRequests || this.timestampRequests,
     timestampParam: options.timestampParam || this.timestampParam,
     policyPort: options.policyPort || this.policyPort,
-    socket: this,
     pfx: options.pfx || this.pfx,
     key: options.key || this.key,
     passphrase: options.passphrase || this.passphrase,
@@ -195,7 +195,8 @@ Socket.prototype.createTransport = function (name) {
     perMessageDeflate: options.perMessageDeflate || this.perMessageDeflate,
     extraHeaders: options.extraHeaders || this.extraHeaders,
     forceNode: options.forceNode || this.forceNode,
-    localAddress: options.localAddress || this.localAddress
+    localAddress: options.localAddress || this.localAddress,
+    requestTimeout: options.requestTimeout || this.requestTimeout
   });
 
   return transport;


### PR DESCRIPTION
To be used as:

```js
io({ 
  transportOptions: {
    polling: { /* opts */ },
    websocket: { /* opts */ }
  }
});
```

Closes https://github.com/socketio/engine.io-client/pull/480