### PR TITLE
Allow extraHeaders to be set for browser clients in XHR requests

### DIFF
--- a/lib/transports/polling-xhr.js
+++ b/lib/transports/polling-xhr.js
@@ -31,6 +31,7 @@ function empty () {}
 function XHR (opts) {
   Polling.call(this, opts);
   this.requestTimeout = opts.requestTimeout;
+  this.extraHeaders = opts.extraHeaders;
 
   if (global.location) {
     var isSSL = 'https:' === location.protocol;
@@ -44,8 +45,6 @@ function XHR (opts) {
     this.xd = opts.hostname !== global.location.hostname ||
       port !== opts.port;
     this.xs = opts.secure !== isSSL;
-  } else {
-    this.extraHeaders = opts.extraHeaders;
   }
 }
 

--- a/test/transport.js
+++ b/test/transport.js
@@ -294,4 +294,22 @@ describe('Transport', function () {
       });
     });
   }
+
+  describe('options', function () {
+    it('should accept an `extraHeaders` option for XMLHttpRequest in browser', function () {
+      var headers = {
+        'X-Custom-Header-For-My-Project': 'my-secret-access-token',
+        'Cookie': 'user_session=NI2JlCKF90aE0sJZD9ZzujtdsUqNYSBYxzlTsvdSUe35ZzdtVRGqYFr0kdGxbfc5gUOkR9RGp20GVKza; path=/; expires=Tue, 07-Apr-2015 18:18:08 GMT; secure; HttpOnly'
+      };
+      var socket = new eio.Socket({
+        transportOptions: {
+          polling: {
+            extraHeaders: headers
+          }
+        }
+      });
+      expect(socket.transport.name).to.be('polling');
+      expect(socket.transport.extraHeaders).to.equal(headers);
+    });
+  });
 });


### PR DESCRIPTION
To be used as (after https://github.com/socketio/engine.io-client/pull/518 is merged):
```js
io({ 
  transportOptions: {
    polling: {
      extraHeaders: { 'X-Requested-With': 'XMLHttpRequest' }
    },
  }
});
```


Closes https://github.com/socketio/engine.io-client/issues/410