### PR TITLE
Unref timers for a clean exit after close

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -517,7 +517,7 @@ Socket.prototype.setPing = function () {
     self.ping();
     self.onHeartbeat(self.pingTimeout);
   }, self.pingInterval);
-  if (self.pinIntervalTimer.unref) self.pingInterval.unref();
+  if (self.pingIntervalTimer.unref) self.pingIntervalTimer.unref();
 };
 
 /**

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -499,7 +499,7 @@ Socket.prototype.onHeartbeat = function (timeout) {
     if ('closed' === self.readyState) return;
     self.onClose('ping timeout');
   }, timeout || (self.pingInterval + self.pingTimeout));
-  if (self.pingTimeoutTimer.unref) self.pingTimeoutTimer.unref()
+  if (self.pingTimeoutTimer.unref) self.pingTimeoutTimer.unref();
 };
 
 /**
@@ -517,7 +517,7 @@ Socket.prototype.setPing = function () {
     self.ping();
     self.onHeartbeat(self.pingTimeout);
   }, self.pingInterval);
-  if (self.pinIntervalTimer.unref) self.pingInterval.unref()
+  if (self.pinIntervalTimer.unref) self.pingInterval.unref();
 };
 
 /**

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -499,6 +499,7 @@ Socket.prototype.onHeartbeat = function (timeout) {
     if ('closed' === self.readyState) return;
     self.onClose('ping timeout');
   }, timeout || (self.pingInterval + self.pingTimeout));
+  if (self.pingTimeoutTimer.unref) self.pingTimeoutTimer.unref()
 };
 
 /**
@@ -516,6 +517,7 @@ Socket.prototype.setPing = function () {
     self.ping();
     self.onHeartbeat(self.pingTimeout);
   }, self.pingInterval);
+  if (self.pinIntervalTimer.unref) self.pingInterval.unref()
 };
 
 /**


### PR DESCRIPTION
*Note*: the `engine.io.js` file is the generated output of `make engine.io.js`, and should not be manually modified.

### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour
Not calling unref on the timers

### New behaviour
Unref called on the timers, if available.

### Other information (e.g. related issues)
Issue: https://github.com/socketio/engine.io-client/issues/528

