### PR TITLE
Add a warning about a potential URL error in CORS situation

### DIFF
--- a/lib/transports/polling-xhr.js
+++ b/lib/transports/polling-xhr.js
@@ -125,6 +125,10 @@ XHR.prototype.doPoll = function () {
     self.onData(data);
   });
   req.on('error', function (err) {
+    if (this.xd) {
+      // failed request in cross-domain situation
+      console.warn('the server at [' + this.uri + '] did not respond properly, could you please make sure the URI is valid?');
+    }
     self.onError('xhr poll error', err);
   });
   this.pollXhr = req;


### PR DESCRIPTION
*Note*: the `engine.io.js` file is the generated output of `make engine.io.js`, and should not be manually modified.

### The kind of change this PR does introduce

* a new feature

From https://github.com/socketio/socket.io/issues/1979#issue-56424161:
> A lot of people seem to be mistaking the error No 'Access-Control-Allow-Origin' header is present on the requested resource for lack of CORS support in Socket.IO.
> This seems to be due to usually trying to initialize a socket to the wrong URL. The URL exists and responds, but obviously it doesn't set CORS headers. And even if it did, it wouldn't be where the socket.io server is hosted.

Or the remote server sets `Access-Control-Allow-Origin: *`, triggering `A wildcard '*' cannot be used in the 'Access-Control-Allow-Origin' header when the credentials flag is true.`

Example:
```
var socket = io('google.com');
// in the console
> Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote resource at http://google.com/socket.io/?EIO=3&transport=polling&t=LcyR-zj. (Reason: CORS header 'Access-Control-Allow-Origin' missing).
> the server at [http://google.com/socket.io/?EIO=3&transport=polling&t=LcyS5DF] did not respond properly, could you please make sure the URI is valid?
```

Related:
- https://github.com/socketio/socket.io/issues/1979
- https://github.com/socketio/socket.io/issues/2740

