### PR TITLE
Use uws by default, fallback to ws. Fixed #530

### DIFF
--- a/lib/transports/websocket.js
+++ b/lib/transports/websocket.js
@@ -12,8 +12,10 @@ var BrowserWebSocket = global.WebSocket || global.MozWebSocket;
 var NodeWebSocket;
 if (typeof window === 'undefined') {
   try {
+    NodeWebSocket = require('uws');
+  } catch (e) {
     NodeWebSocket = require('ws');
-  } catch (e) { }
+  }
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -64,10 +64,14 @@
     "zuul-builder-webpack": "1.1.0",
     "zuul-ngrok": "4.0.0"
   },
+  "optionalDependencies": {
+    "uws": "0.12.0"
+  },
   "scripts": {
     "test": "gulp test"
   },
   "browser": {
+    "uws": false,
     "ws": false,
     "xmlhttprequest-ssl": "./lib/xmlhttprequest.js"
   },


### PR DESCRIPTION
*Note*: the `engine.io.js` file is the generated output of `make engine.io.js`, and should not be manually modified.

### The kind of change this PR does introduce

* [ ] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [x] a code change that improves performance
* [ ] other

### Current behaviour
Client uses ws by default on node

### New behaviour
Client tries to use uws, fallback to ws

### Other information (e.g. related issues)
https://github.com/socketio/engine.io-client/issues/530

