### PR TITLE
concat-stream known to be vulnerable prior 1.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "babel-loader": "6.2.1",
     "babel-preset-es2015": "6.3.13",
     "blob": "0.0.4",
-    "concat-stream": "1.4.6",
+    "concat-stream": "1.5.2",
     "del": "2.2.0",
     "derequire": "1.2.0",
     "engine.io": "2.0.2",


### PR DESCRIPTION
https://snyk.io/vuln/npm:concat-stream:20160901?utm_source=slack


*Note*: the `engine.io.js` file is the generated output of `make engine.io.js`, and should not be manually modified.

### The kind of change this PR does introduce

* [ ] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [x] other

### Current behaviour

concat-stream is known to be vulnerable

### New behaviour

concat-stream no longer vulnerable

### Other information (e.g. related issues)

https://snyk.io/vuln/npm:concat-stream:20160901?utm_source=slack
