### PR TITLE
Release 2.1.0

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,4 +1,11 @@
 
+2.1.0  / 2017-03-11
+===================
+
+  * [chore] Bump engine.io-parser to version 2.0.1 (#549)
+  * [chore] Bump concat-stream to version 1.5.2 (#548)
+  * [feat] Allow to set the protocols for the websocket transport (#546)
+
 2.0.2  / 2017-02-16
 ===================
 

--- a/engine.io.js
+++ b/engine.io.js
@@ -276,7 +276,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	    extraHeaders: options.extraHeaders || this.extraHeaders,
 	    forceNode: options.forceNode || this.forceNode,
 	    localAddress: options.localAddress || this.localAddress,
-	    requestTimeout: options.requestTimeout || this.requestTimeout
+	    requestTimeout: options.requestTimeout || this.requestTimeout,
+	    protocols: options.protocols || void 0
 	  });
 
 	  return transport;
@@ -4346,6 +4347,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  }
 	  this.perMessageDeflate = opts.perMessageDeflate;
 	  this.usingBrowserWebSocket = BrowserWebSocket && !opts.forceNode;
+	  this.protocols = opts.protocols;
 	  if (!this.usingBrowserWebSocket) {
 	    WebSocket = NodeWebSocket;
 	  }
@@ -4385,7 +4387,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  }
 
 	  var uri = this.uri();
-	  var protocols = void 0;
+	  var protocols = this.protocols;
 	  var opts = {
 	    agent: this.agent,
 	    perMessageDeflate: this.perMessageDeflate
@@ -4407,7 +4409,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  }
 
 	  try {
-	    this.ws = this.usingBrowserWebSocket ? new WebSocket(uri) : new WebSocket(uri, protocols, opts);
+	    this.ws = this.usingBrowserWebSocket ? protocols ? new WebSocket(uri, protocols) : new WebSocket(uri) : new WebSocket(uri, protocols, opts);
 	  } catch (err) {
 	    return this.emit('error', err);
 	  }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "concat-stream": "1.5.2",
     "del": "2.2.0",
     "derequire": "1.2.0",
-    "engine.io": "2.0.2",
+    "engine.io": "2.1.0",
     "eslint-config-standard": "4.4.0",
     "eslint-plugin-standard": "1.3.1",
     "expect.js": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "engine.io-client",
   "description": "Client for the realtime Engine",
   "license": "MIT",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "homepage": "https://github.com/socketio/engine.io-client",
   "contributors": [
     {


### PR DESCRIPTION
Changelog:

* [chore] Bump engine.io-parser to version 2.0.1 (#549)
* [chore] Bump concat-stream to version 1.5.2 (#548)
* [feat] Allow to set the protocols for the websocket transport (#546)