### PR TITLE
bump engine.io-parser to version 2.0.2

### DIFF
--- a/lib/transports/polling.js
+++ b/lib/transports/polling.js
@@ -145,7 +145,7 @@ Polling.prototype.onData = function (data) {
   };
 
   // decode payload
-  parser.decodePayload(data, this.socket.binaryType, callback);
+  parser.decodePayload(data, this.socket.binaryType, this.supportsBinary, callback);
 
   // if an event did not trigger closing
   if ('closed' !== this.readyState) {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "component-emitter": "1.2.1",
     "component-inherit": "0.0.3",
     "debug": "2.3.3",
-    "engine.io-parser": "2.0.1",
+    "engine.io-parser": "2.0.2",
     "has-cors": "1.1.0",
     "indexof": "0.0.1",
     "parsejson": "0.0.3",


### PR DESCRIPTION
Following https://github.com/socketio/engine.io-parser/pull/85 and https://github.com/socketio/engine.io-parser/pull/88.