### PR TITLE
default `rejectUnauthorized` to `true`

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -92,7 +92,7 @@ function Socket (uri, opts) {
   this.cert = opts.cert || null;
   this.ca = opts.ca || null;
   this.ciphers = opts.ciphers || null;
-  this.rejectUnauthorized = opts.rejectUnauthorized === undefined ? null : opts.rejectUnauthorized;
+  this.rejectUnauthorized = opts.rejectUnauthorized === undefined ? true : opts.rejectUnauthorized;
   this.forceNode = !!opts.forceNode;
 
   // other options for Node.js client


### PR DESCRIPTION
That follows https://github.com/socketio/engine.io-client/pull/496, since support for nodejs 0.10 was dropped (https://github.com/socketio/engine.io-client/pull/557).