### PR TITLE
Update socket.js

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -235,9 +235,13 @@ Socket.prototype.open = function () {
   this.readyState = 'opening';
 
   // Retry with the next transport if the transport is disabled (jsonp: false)
+  var hasError = false;
   try {
     transport = this.createTransport(transport);
   } catch (e) {
+    hasError = true;
+  }
+  if (hasError || (typeof transport.check == 'function' && !transport.check())) {
     this.transports.shift();
     this.open();
     return;


### PR DESCRIPTION
These changes support transports to be one array which try websocket first, such as '[ 'websocket', 'polling']'.
The purpose is that we hope to give priority to websocket when implementing socket, in that polling will be blocked by the firewall instead of upgrading to websocket in some networked environments subject to security rules. But in ie9 - , it doesn’t support websocket, so we need to try the next protocol from the array of transports. The changes above are to achieve such a mechanism.


*Note*: the `engine.io.js` file is the generated output of `make engine.io.js`, and should not be manually modified.

### The kind of change this PR does introduce

* [ ] a bug fix
* [*] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour
If set transports as ['websocket', 'polling'], it couldn't try polling when IE 9- doses not supports websocket.

### New behaviour
If browser supports websocket , the socket would use websocket immediatly.
If browser does not supports websocket , the socket would use polling when failed to try websocket.

### Other information (e.g. related issues)


