### PR TITLE
Set responseType based on response content-type header

### DIFF
--- a/lib/transports/polling-xhr.js
+++ b/lib/transports/polling-xhr.js
@@ -205,11 +205,6 @@ Request.prototype.create = function () {
         }
       }
     } catch (e) {}
-    if (this.supportsBinary) {
-      // This has to be done after open because Firefox is stupid
-      // http://stackoverflow.com/questions/13216903/get-binary-data-with-xmlhttprequest-in-a-firefox-extension
-      xhr.responseType = 'arraybuffer';
-    }
 
     if ('POST' === this.method) {
       try {
@@ -243,6 +238,12 @@ Request.prototype.create = function () {
       };
     } else {
       xhr.onreadystatechange = function () {
+        if (xhr.readyState === 2) {
+          var contentType = xhr.getResponseHeader('Content-Type');
+          if (contentType === 'application/octet-stream') {
+            xhr.responseType = 'arraybuffer';
+          }
+        }
         if (4 !== xhr.readyState) return;
         if (200 === xhr.status || 1223 === xhr.status) {
           self.onLoad();
@@ -346,28 +347,11 @@ Request.prototype.cleanup = function (fromError) {
 Request.prototype.onLoad = function () {
   var data;
   try {
-    var contentType;
-    try {
-      contentType = this.xhr.getResponseHeader('Content-Type').split(';')[0];
-    } catch (e) {}
+    var contentType = this.xhr.getResponseHeader('Content-Type');
     if (contentType === 'application/octet-stream') {
-      data = this.xhr.response || this.xhr.responseText;
+      data = this.xhr.response;
     } else {
-      if (!this.supportsBinary) {
-        data = this.xhr.responseText;
-      } else {
-        try {
-          data = String.fromCharCode.apply(null, new Uint8Array(this.xhr.response));
-        } catch (e) {
-          var ui8Arr = new Uint8Array(this.xhr.response);
-          var dataArray = [];
-          for (var idx = 0, length = ui8Arr.length; idx < length; idx++) {
-            dataArray.push(ui8Arr[idx]);
-          }
-
-          data = String.fromCharCode.apply(null, dataArray);
-        }
-      }
+      data = this.xhr.responseText;
     }
   } catch (e) {
     this.onError(e);

--- a/lib/transports/polling-xhr.js
+++ b/lib/transports/polling-xhr.js
@@ -239,7 +239,10 @@ Request.prototype.create = function () {
     } else {
       xhr.onreadystatechange = function () {
         if (xhr.readyState === 2) {
-          var contentType = xhr.getResponseHeader('Content-Type');
+          var contentType;
+          try {
+            contentType = xhr.getResponseHeader('Content-Type');
+          } catch (e) {}
           if (contentType === 'application/octet-stream') {
             xhr.responseType = 'arraybuffer';
           }
@@ -347,9 +350,12 @@ Request.prototype.cleanup = function (fromError) {
 Request.prototype.onLoad = function () {
   var data;
   try {
-    var contentType = this.xhr.getResponseHeader('Content-Type');
+    var contentType;
+    try {
+      contentType = this.xhr.getResponseHeader('Content-Type');
+    } catch (e) {}
     if (contentType === 'application/octet-stream') {
-      data = this.xhr.response;
+      data = this.xhr.response || this.xhr.responseText;
     } else {
       data = this.xhr.responseText;
     }

--- a/lib/transports/polling.js
+++ b/lib/transports/polling.js
@@ -145,7 +145,7 @@ Polling.prototype.onData = function (data) {
   };
 
   // decode payload
-  parser.decodePayload(data, this.socket.binaryType, this.supportsBinary, callback);
+  parser.decodePayload(data, this.socket.binaryType, false, callback);
 
   // if an event did not trigger closing
   if ('closed' !== this.readyState) {


### PR DESCRIPTION
*Note*: the `engine.io.js` file is the generated output of `make engine.io.js`, and should not be manually modified.

### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [x] a code change that improves performance
* [ ] other

### Current behaviour

Always set responseType to arraybuffer

### New behaviour

Set responseType based on the reponse headers

### Other information (e.g. related issues)


