### PR TITLE
Launch browser tests on localhost by default

### DIFF
--- a/zuul.config.js
+++ b/zuul.config.js
@@ -1,12 +1,17 @@
 
-module.exports = {
+var zuulConfig = module.exports = {
   ui: 'mocha-bdd',
   server: './test/support/server.js',
-  tunnel: {
-    type: 'ngrok',
-    authtoken: '6Aw8vTgcG5EvXdQywVvbh_3fMxvd4Q7dcL2caAHAFjV',
-    proto: 'tcp'
-  },
+  local: true, // test on localhost by default
   builder: 'zuul-builder-webpack',
   webpack: require('./support/webpack.config.js')
 };
+
+if (process.env.CI === 'true') {
+  zuulConfig.local = false;
+  zuulConfig.tunnel = {
+    type: 'ngrok',
+    authtoken: '6Aw8vTgcG5EvXdQywVvbh_3fMxvd4Q7dcL2caAHAFjV',
+    proto: 'tcp'
+  };
+}


### PR DESCRIPTION
*Note*: the `engine.io.js` file is the generated output of `make engine.io.js`, and should not be manually modified.

### The kind of change this PR does introduce

* other

### Current behaviour


### New behaviour


### Other information (e.g. related issues)


