### PR TITLE
Remove parsejson NPM package

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -8,7 +8,6 @@ var debug = require('debug')('engine.io-client:socket');
 var index = require('indexof');
 var parser = require('engine.io-parser');
 var parseuri = require('parseuri');
-var parsejson = require('parsejson');
 var parseqs = require('parseqs');
 
 /**
@@ -439,7 +438,7 @@ Socket.prototype.onPacket = function (packet) {
 
     switch (packet.type) {
       case 'open':
-        this.onHandshake(parsejson(packet.data));
+        this.onHandshake(JSON.parse(packet.data));
         break;
 
       case 'pong':

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "engine.io-parser": "~2.1.1",
     "has-cors": "1.1.0",
     "indexof": "0.0.1",
-    "parsejson": "0.0.3",
     "parseqs": "0.0.5",
     "parseuri": "0.0.5",
     "ws": "~2.3.1",


### PR DESCRIPTION
Prevents a potential ReDoS. See here: https://nodesecurity.io/advisories/528

I couldn't find any benefits to using parsejson; It seems to just call JSON.parse if it exists, and it exists in every node version, and every browser released since 2008.

Should I run the `make` and include it in this PR, or is that done by a build server or something along those lines?

### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [x] a code change that improves performance
* [ ] other

### Current behaviour

Potential ReDoS for large strings due to `parsejson` package.

### New behaviour

Removes `parsejson` in favour of native parsing.

### Other information (e.g. related issues)

Reported here: #579