### PR TITLE
remove IE6 and IE7 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 node_js:
   - '4'
   - '6'
-  - '7'
+  - '8'
 git:
   depth: 1
 notifications:
@@ -16,10 +16,6 @@ matrix:
     env: BROWSER_NAME=safari BROWSER_VERSION=latest
   - node_js: 'node'
     env: BROWSER_NAME=firefox BROWSER_VERSION=latest
-  - node_js: 'node'
-    env: BROWSER_NAME=ie BROWSER_VERSION=6
-  - node_js: 'node'
-    env: BROWSER_NAME=ie BROWSER_VERSION=7
   - node_js: 'node'
     env: BROWSER_NAME=ie BROWSER_VERSION=8
   - node_js: 'node'


### PR DESCRIPTION
Related: https://wiki.saucelabs.com/pages/viewpage.action?pageId=70068108

```
Hi Sauce user,

Due to very low usage Sauce Labs will be ending support for Windows XP and Mac OS 10.8. With the elimination of these platforms, users will no longer be able to run automated or manual tests on the following browsers from July 30th
- Internet Explorer 6, Internet Explorer 7 (Including all minor versions)
- Internet Explorer 8.0.6001
- Safari 5 and 6

IE 8.0.7601 will continue to be supported through the Windows 7 platform.
```

