### PR TITLE
Chore: Bump ws version to ~3.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "indexof": "0.0.1",
     "parseqs": "0.0.5",
     "parseuri": "0.0.5",
-    "ws": "~2.3.1",
+    "ws": "~3.3.1",
     "xmlhttprequest-ssl": "~1.5.4",
     "yeast": "0.1.2"
   },


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour

N/A

### New behaviour

N/A

### Other information (e.g. related issues)

Was previously ~2.3.1; Bumped due to potential DOS issue. See here: https://nodesecurity.io/advisories/550

There were some breaking changes in v3.0.0, however they don't seem to affect anything here. That being said, someone who's more familiar should probably take another look. Breaking changes are seen here: https://github.com/websockets/ws/releases/tag/3.0.0