### PR TITLE
try/catch xhr.responseType to avoid exception

### DIFF
--- a/lib/transports/polling-xhr.js
+++ b/lib/transports/polling-xhr.js
@@ -239,16 +239,12 @@ Request.prototype.create = function () {
     } else {
       xhr.onreadystatechange = function () {
         if (xhr.readyState === 2) {
-          var contentType;
           try {
-            contentType = xhr.getResponseHeader('Content-Type');
-          } catch (e) {}
-          if (contentType === 'application/octet-stream') {
-            // next line can sometimes cause an exception in Android 4.x
-            try {
+            var contentType = xhr.getResponseHeader('Content-Type');
+            if (contentType === 'application/octet-stream') {
               xhr.responseType = 'arraybuffer';
-            } catch (e) {}
-          }
+            }
+          } catch (e) {}
         }
         if (4 !== xhr.readyState) return;
         if (200 === xhr.status || 1223 === xhr.status) {

--- a/lib/transports/polling-xhr.js
+++ b/lib/transports/polling-xhr.js
@@ -244,7 +244,10 @@ Request.prototype.create = function () {
             contentType = xhr.getResponseHeader('Content-Type');
           } catch (e) {}
           if (contentType === 'application/octet-stream') {
-            xhr.responseType = 'arraybuffer';
+            // next line can sometimes cause an exception in Android 4.x
+            try {
+              xhr.responseType = 'arraybuffer';
+            } catch (e) {}
           }
         }
         if (4 !== xhr.readyState) return;


### PR DESCRIPTION
The line can cause exceptions on Android 4.x in certain circumstances.

Unfortunately, not reproducible but only visible when logging client errors in production, see https://github.com/socketio/engine.io-client/issues/589

*Note*: the `engine.io.js` file is the generated output of `make engine.io.js`, and should not be manually modified.

### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour

When logging the JS errors our clients experience, we see quite some significant numbers of  

INVALID_STATE_ERR: DOM Exception 11

in chrome on android 4.x and some opera browsers. It is not reproducible, though.

### New behaviour

When putting the line in a try/catch, no more errors are logged AND there a no NEW ones, so it looks like it is improving the experience.


### Other information (e.g. related issues)

https://github.com/socketio/engine.io-client/issues/589

