### PR TITLE
Detect React-Native environment and use all websocket features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build
 components
 /coverage
 npm-debug.log
+.idea

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -94,9 +94,12 @@ function Socket (uri, opts) {
   this.rejectUnauthorized = opts.rejectUnauthorized === undefined ? true : opts.rejectUnauthorized;
   this.forceNode = !!opts.forceNode;
 
-  // other options for Node.js client
+  // detect ReactNative environment
+  this.isReactNative = (typeof navigator !== 'undefined' && typeof navigator.product === 'string' && navigator.product.toLowerCase() === 'reactnative');
+
+  // other options for Node.js or ReactNative client
   var freeGlobal = typeof global === 'object' && global;
-  if (freeGlobal.global === freeGlobal) {
+  if (freeGlobal.global === freeGlobal || this.isReactNative) {
     if (opts.extraHeaders && Object.keys(opts.extraHeaders).length > 0) {
       this.extraHeaders = opts.extraHeaders;
     }
@@ -196,7 +199,8 @@ Socket.prototype.createTransport = function (name) {
     forceNode: options.forceNode || this.forceNode,
     localAddress: options.localAddress || this.localAddress,
     requestTimeout: options.requestTimeout || this.requestTimeout,
-    protocols: options.protocols || void (0)
+    protocols: options.protocols || void (0),
+    isReactNative: this.isReactNative
   });
 
   return transport;

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -41,6 +41,9 @@ function Transport (opts) {
   this.rejectUnauthorized = opts.rejectUnauthorized;
   this.forceNode = opts.forceNode;
 
+  // results of ReactNative environment detection
+  this.isReactNative = opts.isReactNative;
+
   // other options for Node.js client
   this.extraHeaders = opts.extraHeaders;
   this.localAddress = opts.localAddress;

--- a/lib/transports/websocket.js
+++ b/lib/transports/websocket.js
@@ -109,7 +109,7 @@ WS.prototype.doOpen = function () {
   }
 
   try {
-    this.ws = this.usingBrowserWebSocket ? (protocols ? new WebSocket(uri, protocols) : new WebSocket(uri)) : new WebSocket(uri, protocols, opts);
+    this.ws = this.usingBrowserWebSocket && !this.isReactNative ? (protocols ? new WebSocket(uri, protocols) : new WebSocket(uri)) : new WebSocket(uri, protocols, opts);
   } catch (err) {
     return this.emit('error', err);
   }


### PR DESCRIPTION
React-Native provides a Websocket object that is more functionally aligned with the Node.js websocket than the browser websocket.

It has the same constructor signature as the Node.js websocket and can support extraHeaders and protocols.

This PR will detect when the engine.io-client is running in React-Native, call the proper Websocket constructor, and enable support for extraHeaders.


*Note*: the `engine.io.js` file is the generated output of `make engine.io.js`, and should not be manually modified.

### The kind of change this PR does introduce

* [ ] a bug fix
* [x] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour

When running engine.io-client in a React-Native environment, the websocket transport cannot use extraHeaders.

### New behaviour

When running engine.io-client in a React-Native environment, the websocket transport can use extraHeaders

### Other information (e.g. related issues)


