### PR TITLE
fix: use try/catch when setting xhr.responseType

### DIFF
--- a/lib/transports/polling-xhr.js
+++ b/lib/transports/polling-xhr.js
@@ -220,6 +220,10 @@ Request.prototype.create = function () {
       xhr.setRequestHeader('Accept', '*/*');
     } catch (e) {}
 
+    if (this.supportsBinary) {
+      xhr.responseType = 'arraybuffer';
+    }
+
     // ie6 check
     if ('withCredentials' in xhr) {
       xhr.withCredentials = true;
@@ -239,13 +243,12 @@ Request.prototype.create = function () {
     } else {
       xhr.onreadystatechange = function () {
         if (xhr.readyState === 2) {
-          var contentType;
           try {
-            contentType = xhr.getResponseHeader('Content-Type');
+            var contentType = xhr.getResponseHeader('Content-Type');
+            if (contentType !== 'application/octet-stream') {
+              xhr.responseType = 'text';
+            }
           } catch (e) {}
-          if (contentType === 'application/octet-stream') {
-            xhr.responseType = 'arraybuffer';
-          }
         }
         if (4 !== xhr.readyState) return;
         if (200 === xhr.status || 1223 === xhr.status) {
@@ -355,7 +358,11 @@ Request.prototype.onLoad = function () {
       contentType = this.xhr.getResponseHeader('Content-Type');
     } catch (e) {}
     if (contentType === 'application/octet-stream') {
-      data = this.xhr.response || this.xhr.responseText;
+      if (this.xhr.responseType === 'arraybuffer') {
+        data = this.xhr.response || this.xhr.responseText;
+      } else {
+        data = String.fromCharCode.apply(null, new Uint8Array(this.xhr.response));
+      }
     } else {
       data = this.xhr.responseText;
     }


### PR DESCRIPTION
Some XHR implementations (like Firefox WebWorker, react-native and some Android 4.x versions) throw
an exception when setting xhr.responseType = 'arraybuffer' when xhr.readyState === 2 (which is
perfectly valid, spec-wise).

That commit fixes that behaviour by reverting some of the changes from
https://github.com/socketio/engine.io-client/pull/562 for those implementations.

Closes #590


*Note*: the `engine.io.js` file is the generated output of `make engine.io.js`, and should not be manually modified.

### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour


### New behaviour


### Other information (e.g. related issues)


