### PR TITLE
add test demonstrating #595 in firefox

### DIFF
--- a/lib/transports/polling-xhr.js
+++ b/lib/transports/polling-xhr.js
@@ -220,7 +220,6 @@ Request.prototype.create = function () {
       xhr.setRequestHeader('Accept', '*/*');
     } catch (e) {}
 
-
     // ie6 check
     if ('withCredentials' in xhr) {
       xhr.withCredentials = true;

--- a/lib/transports/polling-xhr.js
+++ b/lib/transports/polling-xhr.js
@@ -220,9 +220,6 @@ Request.prototype.create = function () {
       xhr.setRequestHeader('Accept', '*/*');
     } catch (e) {}
 
-    if (this.supportsBinary) {
-      xhr.responseType = 'arraybuffer';
-    }
 
     // ie6 check
     if ('withCredentials' in xhr) {
@@ -245,8 +242,8 @@ Request.prototype.create = function () {
         if (xhr.readyState === 2) {
           try {
             var contentType = xhr.getResponseHeader('Content-Type');
-            if (contentType !== 'application/octet-stream') {
-              xhr.responseType = 'text';
+            if (self.supportsBinary && contentType === 'application/octet-stream') {
+              xhr.responseType = 'arraybuffer';
             }
           } catch (e) {}
         }

--- a/lib/transports/polling-xhr.js
+++ b/lib/transports/polling-xhr.js
@@ -355,8 +355,6 @@ Request.prototype.onLoad = function () {
     } catch (e) {}
     if (contentType === 'application/octet-stream') {
       data = this.xhr.response || this.xhr.responseText;
-    } else if (this.xhr.responseType === 'arraybuffer') {
-      data = String.fromCharCode.apply(null, new Uint8Array(this.xhr.response));
     } else {
       data = this.xhr.responseText;
     }

--- a/test/connection.js
+++ b/test/connection.js
@@ -62,9 +62,19 @@ describe('connection', function () {
   if (global.Worker) {
     it('should work in a worker', function (done) {
       var worker = new Worker('/test/support/worker.js');
+      var msg = 0;
+      var utf8yay = 'пойду сать всем мпокойной ночи';
       worker.onmessage = function (e) {
-        expect(e.data);
-        done();
+        if (msg === 0) {
+          msg++;
+          expect(e.data).to.be('hi');
+        } else if (msg < 10) {
+          msg++;
+          expect(e.data).to.be(utf8yay);
+        } else {
+          expect(e.data).to.be(utf8yay);
+          done();
+        }
       };
     });
   }

--- a/test/connection.js
+++ b/test/connection.js
@@ -65,17 +65,25 @@ describe('connection', function () {
       var msg = 0;
       var utf8yay = 'пойду сать всем мпокойной ночи';
       worker.onmessage = function (e) {
-        if (msg === 0) {
-          msg++;
+        msg++;
+        if (msg === 1) {
           expect(e.data).to.be('hi');
-        } else if (msg < 10) {
-          msg++;
+        } else if (msg < 11) {
           expect(e.data).to.be(utf8yay);
+        } else if (msg < 20) {
+          testBinary(e.data);
         } else {
-          expect(e.data).to.be(utf8yay);
+          testBinary(e.data);
           done();
         }
       };
+
+      function testBinary(data) {
+        var byteArray = new Uint8Array(data);
+        for (var i = 0; i < byteArray.byteLength; i++) {
+          expect(byteArray[i]).to.be(i);
+        }
+      }
     });
   }
 

--- a/test/connection.js
+++ b/test/connection.js
@@ -78,7 +78,7 @@ describe('connection', function () {
         }
       };
 
-      function testBinary(data) {
+      function testBinary (data) {
         var byteArray = new Uint8Array(data);
         for (var i = 0; i < byteArray.byteLength; i++) {
           expect(byteArray[i]).to.be(i);

--- a/test/support/public/worker.js
+++ b/test/support/public/worker.js
@@ -6,9 +6,11 @@ var socket = new eio.Socket();
 
 var count = 0;
 socket.on('message', function (msg) {
+  count++
   if (count < 10) {
-    count++
     socket.send('give utf8');
+  } else if(count < 20) {
+    socket.send('give binary');
   }
   postMessage(msg);
 });

--- a/test/support/public/worker.js
+++ b/test/support/public/worker.js
@@ -3,6 +3,12 @@
 importScripts('/test/support/engine.io.js');
 
 var socket = new eio.Socket();
+
+var count = 0;
 socket.on('message', function (msg) {
+  if (count < 10) {
+    count++
+    socket.send('give utf8');
+  }
   postMessage(msg);
 });

--- a/test/support/public/worker.js
+++ b/test/support/public/worker.js
@@ -6,10 +6,10 @@ var socket = new eio.Socket();
 
 var count = 0;
 socket.on('message', function (msg) {
-  count++
+  count++;
   if (count < 10) {
     socket.send('give utf8');
-  } else if(count < 20) {
+  } else if (count < 20) {
     socket.send('give binary');
   }
   postMessage(msg);

--- a/test/support/server.js
+++ b/test/support/server.js
@@ -33,7 +33,7 @@ server.on('connection', function (socket) {
       socket.send(abv);
       return;
     } else if (data === 'give utf8') {
-      socket.send("пойду сать всем мпокойной ночи");
+      socket.send('пойду сать всем мпокойной ночи');
       return;
     }
 

--- a/test/support/server.js
+++ b/test/support/server.js
@@ -32,6 +32,9 @@ server.on('connection', function (socket) {
       }
       socket.send(abv);
       return;
+    } else if (data === 'give utf8') {
+      socket.send("пойду сать всем мпокойной ночи");
+      return;
     }
 
     socket.send(data);


### PR DESCRIPTION
this fails for me about half the time in browser: Firefox 58.0.2 (64-bit)

### The kind of change this PR does introduce

* [ ] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [x] other
Test

### Current behaviour
```
connection :: should work in a worker

Error: expected 'Ð¿Ð¾Ð¹Ð´Ñ\u0083 Ñ\u0081Ð°Ñ\u0082Ñ\u008c Ð²Ñ\u0081ÐµÐ¼ Ð' to equal 'пойду сать всем мпокойной ночи' (http://localhost:8080/__zuul/test-bundle.js:413)

    at process.on/global.onerror (__zuul/framework.js:6458:10)
```


### Other information (e.g. related issues)

Issue #595
