### PR TITLE
Improved description accuracy of pfx option 

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Exposed as `eio` in the browser standalone build.
         try websocket. A connection attempt following a transport error will use the
         normal upgrade process. It is recommended you turn this on only when using
         SSL/TLS connections, or if you know that your network does not block websockets.
-      - `pfx` (`String`): Certificate, Private key and CA certificates to use for SSL. Can be used in Node.js client environment to manually specify certificate information.
+      - `pfx` (`String`|`Buffer`): Certificate, Private key and CA certificates to use for SSL. Can be used in Node.js client environment to manually specify certificate information.
       - `key` (`String`): Private key to use for SSL. Can be used in Node.js client environment to manually specify certificate information.
       - `passphrase` (`String`): A string of passphrase for the private key or pfx. Can be used in Node.js client environment to manually specify certificate information.
       - `cert` (`String`): Public x509 certificate to use. Can be used in Node.js client environment to manually specify certificate information.


### PR DESCRIPTION
The pfx option is eventually passed to `tls.createSecureContext(options)`. 
According to the recent node.js reference, not only `String` but also `Buffer` is accepted. 
For this reason, I modified the document to fit.

In real situation, I tried to use a pfx file for client authentication 
but I was a bit confused by the description that type of `pfx` is `String`.
Because, pfx (PKCS#12) file is a binary file.

### The kind of change this PR does introduce

* [ ] a bug fix
* [ ] a new feature
* [x] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour


### New behaviour


### Other information (e.g. related issues)
node.js v.4.x reference: https://nodejs.org/docs/latest-v4.x/api/tls.html#tls_tls_createsecurecontext_details
node.js v.6.x reference: https://nodejs.org/docs/latest-v6.x/api/tls.html#tls_tls_createsecurecontext_options
node.js v.8.x reference: https://nodejs.org/docs/latest-v6.x/api/tls.html#tls_tls_createsecurecontext_options


