### PR TITLE
Fix #603 Trigger xhr polling transport unload handler on pagehide or unload

### DIFF
--- a/lib/transports/polling-xhr.js
+++ b/lib/transports/polling-xhr.js
@@ -401,7 +401,8 @@ if (typeof document !== 'undefined') {
   if (typeof attachEvent === 'function') {
     attachEvent('onunload', unloadHandler);
   } else if (typeof addEventListener === 'function') {
-    addEventListener('beforeunload', unloadHandler, false);
+    var terminationEvent = 'onpagehide' in self ? 'pagehide' : 'unload';
+    addEventListener(terminationEvent, unloadHandler, false);
   }
 }
 


### PR DESCRIPTION
Instead of beforeunload to prevent broke connection on cancelled beforeunload event

### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour
Polling transport breaks every time after `beforeunload` triggered, even if page wasn't closed after event have have has handed.
See #603 

### New behaviour
Trigger xhr polling transport unload handler on `pagehide` or `unload` instead of `beforeunload` to prevent broke connection on cancelled beforeunload event.
