### PR TITLE
Fix Websocket implementation in React Native

### DIFF
--- a/lib/transports/websocket.js
+++ b/lib/transports/websocket.js
@@ -8,13 +8,17 @@ var parseqs = require('parseqs');
 var inherit = require('component-inherit');
 var yeast = require('yeast');
 var debug = require('debug')('engine.io-client:websocket');
+
 var BrowserWebSocket, NodeWebSocket;
-if (typeof self === 'undefined') {
+
+if (typeof WebSocket !== 'undefined') {
+  BrowserWebSocket = WebSocket;
+} else if (typeof self !== 'undefined') {
+  BrowserWebSocket = self.WebSocket || self.MozWebSocket;
+} else {
   try {
     NodeWebSocket = require('ws');
   } catch (e) { }
-} else {
-  BrowserWebSocket = self.WebSocket || self.MozWebSocket;
 }
 
 /**
@@ -23,7 +27,7 @@ if (typeof self === 'undefined') {
  * interface exposed by `ws` for Node-like environment.
  */
 
-var WebSocket = BrowserWebSocket || NodeWebSocket;
+var WebSocketImpl = BrowserWebSocket || NodeWebSocket;
 
 /**
  * Module exports.
@@ -47,7 +51,7 @@ function WS (opts) {
   this.usingBrowserWebSocket = BrowserWebSocket && !opts.forceNode;
   this.protocols = opts.protocols;
   if (!this.usingBrowserWebSocket) {
-    WebSocket = NodeWebSocket;
+    WebSocketImpl = NodeWebSocket;
   }
   Transport.call(this, opts);
 }
@@ -107,7 +111,12 @@ WS.prototype.doOpen = function () {
   }
 
   try {
-    this.ws = this.usingBrowserWebSocket && !this.isReactNative ? (protocols ? new WebSocket(uri, protocols) : new WebSocket(uri)) : new WebSocket(uri, protocols, opts);
+    this.ws =
+      this.usingBrowserWebSocket && !this.isReactNative
+        ? protocols
+          ? new WebSocketImpl(uri, protocols)
+          : new WebSocketImpl(uri)
+        : new WebSocketImpl(uri, protocols, opts);
   } catch (err) {
     return this.emit('error', err);
   }
@@ -280,5 +289,5 @@ WS.prototype.uri = function () {
  */
 
 WS.prototype.check = function () {
-  return !!WebSocket && !('__initialize' in WebSocket && this.name === WS.prototype.name);
+  return !!WebSocketImpl && !('__initialize' in WebSocketImpl && this.name === WS.prototype.name);
 };


### PR DESCRIPTION
*Note*: the `engine.io.js` file is the generated output of `make engine.io.js`, and should not be manually modified.

### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour

In React Native, using the WebSocket transport with socket.io fails. This is because `self` is undefined, so it tries to load in the `ws` Node.js library. It should use the native RN `WebSocket` instead.

### New behaviour

This ensures the correct `WebSocket` global is used.

### Other information (e.g. related issues)

Fixes: https://stackoverflow.com/questions/53650676/expo-with-socket-io-websocket-failing-to-connect
