### PR TITLE
send sid in headers

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -70,6 +70,7 @@ function Socket (uri, opts) {
   this.timestampRequests = opts.timestampRequests;
   this.transports = opts.transports || ['polling', 'websocket'];
   this.transportOptions = opts.transportOptions || {};
+  this.sendSidInHeaders = !!opts.sendSidInHeaders;
   this.readyState = '';
   this.writeBuffer = [];
   this.prevBufferLen = 0;
@@ -169,7 +170,19 @@ Socket.prototype.createTransport = function (name) {
   var options = this.transportOptions[name] || {};
 
   // session id if we already have one
-  if (this.id) query.sid = this.id;
+  var extraHeaders = options.extraHeaders || this.extraHeaders;
+  if (this.id) {
+    if (this.sendSidInHeaders) {
+      if (!extraHeaders) {
+        extraHeaders = {};
+      } else {
+        extraHeaders = clone(extraHeaders);//clone in order to keep (options or this).extraHeaders intact
+      }
+      extraHeaders.sid = this.id;
+    } else {
+      query.sid = this.id;
+    }
+  }
 
   var transport = new transports[name]({
     query: query,
@@ -194,7 +207,7 @@ Socket.prototype.createTransport = function (name) {
     ciphers: options.ciphers || this.ciphers,
     rejectUnauthorized: options.rejectUnauthorized || this.rejectUnauthorized,
     perMessageDeflate: options.perMessageDeflate || this.perMessageDeflate,
-    extraHeaders: options.extraHeaders || this.extraHeaders,
+    extraHeaders: extraHeaders,
     forceNode: options.forceNode || this.forceNode,
     localAddress: options.localAddress || this.localAddress,
     requestTimeout: options.requestTimeout || this.requestTimeout,
@@ -475,7 +488,12 @@ Socket.prototype.onPacket = function (packet) {
 Socket.prototype.onHandshake = function (data) {
   this.emit('handshake', data);
   this.id = data.sid;
-  this.transport.query.sid = data.sid;
+  if (this.sendSidInHeaders) {
+    if (!this.transport.extraHeaders) this.transport.extraHeaders = {};
+    this.transport.extraHeaders.sid = data.sid;
+  } else {
+    this.transport.query.sid = data.sid;
+  }
   this.upgrades = this.filterUpgrades(data.upgrades);
   this.pingInterval = data.pingInterval;
   this.pingTimeout = data.pingTimeout;


### PR DESCRIPTION
*Note*: the `engine.io.js` file is the generated output of `make engine.io.js`, and should not be manually modified.

### The kind of change this PR does introduce

* [ ] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [x] other

### Current behaviour
For now, the sid is sent in the GET request parameters.
OWASP Zed Attack Proxy says there is a security issue
See socketio/socket.io#3416

### New behaviour
I propose to add a sendSidInHeaders  option to the socket constructor and send the sid in the headers instead.

usage (once all merged and compiled)
```
_webSocket = io("/", {
  reconnection: true,
  sendSidInHeaders: true
});
```

### Other information (e.g. related issues)
This pull request must be merged after the engine.io pull request
https://github.com/socketio/engine.io/pull/577

