### PR TITLE
Add withCredentials option

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ Exposed as `eio` in the browser standalone build.
         will be used instead.
       - `forceBase64` (`Boolean`): forces base 64 encoding for polling transport even when XHR2 responseType is available and WebSocket even if the used standard supports binary.
       - `enablesXDR` (`Boolean`): enables XDomainRequest for IE8 to avoid loading bar flashing with click sound. default to `false` because XDomainRequest has a flaw of not sending cookie.
+      - `withCredentials` (`Boolean`): defaults to `true`, whether to include credentials (cookies, authorization headers, TLS client certificates, etc.) with cross-origin XHR polling requests.
       - `timestampRequests` (`Boolean`): whether to add the timestamp with each
         transport request. Note: polling requests are always stamped unless this
         option is explicitly set to `false` (`false`)

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -66,6 +66,7 @@ function Socket (uri, opts) {
   this.jsonp = false !== opts.jsonp;
   this.forceBase64 = !!opts.forceBase64;
   this.enablesXDR = !!opts.enablesXDR;
+  this.withCredentials = false !== opts.withCredentials;
   this.timestampParam = opts.timestampParam || 't';
   this.timestampRequests = opts.timestampRequests;
   this.transports = opts.transports || ['polling', 'websocket'];
@@ -183,6 +184,7 @@ Socket.prototype.createTransport = function (name) {
     jsonp: options.jsonp || this.jsonp,
     forceBase64: options.forceBase64 || this.forceBase64,
     enablesXDR: options.enablesXDR || this.enablesXDR,
+    withCredentials: options.withCredentials || this.withCredentials,
     timestampRequests: options.timestampRequests || this.timestampRequests,
     timestampParam: options.timestampParam || this.timestampParam,
     policyPort: options.policyPort || this.policyPort,

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -30,6 +30,7 @@ function Transport (opts) {
   this.agent = opts.agent || false;
   this.socket = opts.socket;
   this.enablesXDR = opts.enablesXDR;
+  this.withCredentials = opts.withCredentials;
 
   // SSL options for Node.js client
   this.pfx = opts.pfx;

--- a/lib/transports/polling-xhr.js
+++ b/lib/transports/polling-xhr.js
@@ -77,6 +77,7 @@ XHR.prototype.request = function (opts) {
   opts.agent = this.agent || false;
   opts.supportsBinary = this.supportsBinary;
   opts.enablesXDR = this.enablesXDR;
+  opts.withCredentials = this.withCredentials;
 
   // SSL options for Node.js client
   opts.pfx = this.pfx;
@@ -150,6 +151,7 @@ function Request (opts) {
   this.isBinary = opts.isBinary;
   this.supportsBinary = opts.supportsBinary;
   this.enablesXDR = opts.enablesXDR;
+  this.withCredentials = opts.withCredentials;
   this.requestTimeout = opts.requestTimeout;
 
   // SSL options for Node.js client
@@ -224,7 +226,7 @@ Request.prototype.create = function () {
 
     // ie6 check
     if ('withCredentials' in xhr) {
-      xhr.withCredentials = true;
+      xhr.withCredentials = this.withCredentials;
     }
 
     if (this.requestTimeout) {


### PR DESCRIPTION
*Note*: the `engine.io.js` file is the generated output of `make engine.io.js`, and should not be manually modified.

### The kind of change this PR does introduce

* [ ] a bug fix
* [x] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour

`withCredentials` is always set to true, despite the browser default being false, and can't be overridden.

### New behaviour

`withCredentials` can now be overridden back to false if needed.

### Other information (e.g. related issues)

Fixes https://github.com/socketio/engine.io-client/issues/495. Specifically cross-origin requests to servers setting `Access-Control-Allow-Origin: *` break with `xhr.withCredentials = true`.

Similar to the symptom of the recent problem in https://github.com/socketio/socket.io/issues/3381 but a client-side workaround when the server-side can't be changed as it could in that case.