### PR TITLE
add checkServerIdentity option

### DIFF
--- a/engine.io.js
+++ b/engine.io.js
@@ -52,7 +52,7 @@ return /******/ (function(modules) { // webpackBootstrap
 /************************************************************************/
 /******/ ([
 /* 0 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
@@ -66,9 +66,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	 */
 	module.exports.parser = __webpack_require__(8);
 
-/***/ },
+/***/ }),
 /* 1 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
@@ -164,6 +164,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  this.ca = opts.ca || null;
 	  this.ciphers = opts.ciphers || null;
 	  this.rejectUnauthorized = opts.rejectUnauthorized === undefined ? true : opts.rejectUnauthorized;
+	  this.checkServerIdentity = opts.checkServerIdentity || null;
 	  this.forceNode = !!opts.forceNode;
 
 	  // detect ReactNative environment
@@ -810,9 +811,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	  return filteredUpgrades;
 	};
 
-/***/ },
+/***/ }),
 /* 2 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
@@ -870,9 +871,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	  }
 	}
 
-/***/ },
+/***/ }),
 /* 3 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
@@ -914,9 +915,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	  }
 	};
 
-/***/ },
+/***/ }),
 /* 4 */
-/***/ function(module, exports) {
+/***/ (function(module, exports) {
 
 	
 	/**
@@ -937,9 +938,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 
 
-/***/ },
+/***/ }),
 /* 5 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
@@ -1358,9 +1359,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	  }
 	}
 
-/***/ },
+/***/ }),
 /* 6 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
@@ -1609,9 +1610,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	  return schema + '://' + (ipv6 ? '[' + this.hostname + ']' : this.hostname) + port + this.path + query;
 	};
 
-/***/ },
+/***/ }),
 /* 7 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
@@ -1776,9 +1777,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	  this.emit('close');
 	};
 
-/***/ },
+/***/ }),
 /* 8 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	/**
 	 * Module dependencies.
@@ -2387,9 +2388,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 
-/***/ },
+/***/ }),
 /* 9 */
-/***/ function(module, exports) {
+/***/ (function(module, exports) {
 
 	
 	/**
@@ -2412,9 +2413,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 
-/***/ },
+/***/ }),
 /* 10 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	/* global Blob File */
 
@@ -2482,9 +2483,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 
 
-/***/ },
+/***/ }),
 /* 11 */
-/***/ function(module, exports) {
+/***/ (function(module, exports) {
 
 	var toString = {}.toString;
 
@@ -2493,9 +2494,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 
-/***/ },
+/***/ }),
 /* 12 */
-/***/ function(module, exports) {
+/***/ (function(module, exports) {
 
 	/**
 	 * An abstraction for slicing an arraybuffer even when
@@ -2528,9 +2529,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 
-/***/ },
+/***/ }),
 /* 13 */
-/***/ function(module, exports) {
+/***/ (function(module, exports) {
 
 	module.exports = after
 
@@ -2562,9 +2563,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	function noop() {}
 
 
-/***/ },
+/***/ }),
 /* 14 */
-/***/ function(module, exports) {
+/***/ (function(module, exports) {
 
 	/*! https://mths.be/utf8js v2.1.2 by @mathias */
 
@@ -2778,9 +2779,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 
-/***/ },
+/***/ }),
 /* 15 */
-/***/ function(module, exports) {
+/***/ (function(module, exports) {
 
 	/*
 	 * base64-arraybuffer
@@ -2851,9 +2852,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	})();
 
 
-/***/ },
+/***/ }),
 /* 16 */
-/***/ function(module, exports) {
+/***/ (function(module, exports) {
 
 	/**
 	 * Create a blob builder even when vendor prefixes exist
@@ -2957,9 +2958,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	})();
 
 
-/***/ },
+/***/ }),
 /* 17 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	
 	/**
@@ -3126,9 +3127,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 
-/***/ },
+/***/ }),
 /* 18 */
-/***/ function(module, exports) {
+/***/ (function(module, exports) {
 
 	/**
 	 * Compiles a querystring
@@ -3169,9 +3170,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 
-/***/ },
+/***/ }),
 /* 19 */
-/***/ function(module, exports) {
+/***/ (function(module, exports) {
 
 	
 	module.exports = function(a, b){
@@ -3181,9 +3182,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	  a.prototype.constructor = a;
 	};
 
-/***/ },
+/***/ }),
 /* 20 */
-/***/ function(module, exports) {
+/***/ (function(module, exports) {
 
 	'use strict';
 
@@ -3255,9 +3256,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = yeast;
 
 
-/***/ },
+/***/ }),
 /* 21 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	/* WEBPACK VAR INJECTION */(function(process) {/**
 	 * This is the web browser implementation of `debug()`.
@@ -3457,9 +3458,9 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(22)))
 
-/***/ },
+/***/ }),
 /* 22 */
-/***/ function(module, exports) {
+/***/ (function(module, exports) {
 
 	// shim for using process in browser
 	var process = module.exports = {};
@@ -3647,9 +3648,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	process.umask = function() { return 0; };
 
 
-/***/ },
+/***/ }),
 /* 23 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	
 	/**
@@ -3878,9 +3879,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 
 
-/***/ },
+/***/ }),
 /* 24 */
-/***/ function(module, exports) {
+/***/ (function(module, exports) {
 
 	/**
 	 * Helpers.
@@ -4036,9 +4037,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 
 
-/***/ },
+/***/ }),
 /* 25 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	/* WEBPACK VAR INJECTION */(function(global) {'use strict';
 
@@ -4281,9 +4282,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 	/* WEBPACK VAR INJECTION */}.call(exports, (function() { return this; }())))
 
-/***/ },
+/***/ }),
 /* 26 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
@@ -4392,6 +4393,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  opts.ca = this.ca;
 	  opts.ciphers = this.ciphers;
 	  opts.rejectUnauthorized = this.rejectUnauthorized;
+	  opts.checkServerIdentity = this.checkServerIdentity;
 	  if (this.extraHeaders) {
 	    opts.headers = this.extraHeaders;
 	  }
@@ -4575,15 +4577,15 @@ return /******/ (function(modules) { // webpackBootstrap
 	  return !!WebSocketImpl && !('__initialize' in WebSocketImpl && this.name === WS.prototype.name);
 	};
 
-/***/ },
+/***/ }),
 /* 27 */
-/***/ function(module, exports) {
+/***/ (function(module, exports) {
 
 	/* (ignored) */
 
-/***/ },
+/***/ }),
 /* 28 */
-/***/ function(module, exports) {
+/***/ (function(module, exports) {
 
 	
 	var indexOf = [].indexOf;
@@ -4596,9 +4598,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	  return -1;
 	};
 
-/***/ },
+/***/ }),
 /* 29 */
-/***/ function(module, exports) {
+/***/ (function(module, exports) {
 
 	/**
 	 * Parses an URI
@@ -4641,7 +4643,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 
-/***/ }
+/***/ })
 /******/ ])
 });
 ;

--- a/engine.io.js
+++ b/engine.io.js
@@ -266,6 +266,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    ca: options.ca || this.ca,
 	    ciphers: options.ciphers || this.ciphers,
 	    rejectUnauthorized: options.rejectUnauthorized || this.rejectUnauthorized,
+	    checkServerIdentity: options.checkServerIdentity || this.checkServerIdentity,
 	    perMessageDeflate: options.perMessageDeflate || this.perMessageDeflate,
 	    extraHeaders: options.extraHeaders || this.extraHeaders,
 	    forceNode: options.forceNode || this.forceNode,
@@ -1657,6 +1658,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  this.ca = opts.ca;
 	  this.ciphers = opts.ciphers;
 	  this.rejectUnauthorized = opts.rejectUnauthorized;
+	  this.checkServerIdentity = opts.checkServerIdentity || null;
 	  this.forceNode = opts.forceNode;
 
 	  // results of ReactNative environment detection
@@ -4393,7 +4395,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	  opts.ca = this.ca;
 	  opts.ciphers = this.ciphers;
 	  opts.rejectUnauthorized = this.rejectUnauthorized;
-	  opts.checkServerIdentity = this.checkServerIdentity;
+	  if (this.checkServerIdentity) {
+	    opts.checkServerIdentity = this.checkServerIdentity;
+	  }
 	  if (this.extraHeaders) {
 	    opts.headers = this.extraHeaders;
 	  }

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -92,6 +92,7 @@ function Socket (uri, opts) {
   this.ca = opts.ca || null;
   this.ciphers = opts.ciphers || null;
   this.rejectUnauthorized = opts.rejectUnauthorized === undefined ? true : opts.rejectUnauthorized;
+  this.checkServerIdentity = opts.checkServerIdentity || null;
   this.forceNode = !!opts.forceNode;
 
   // detect ReactNative environment

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -194,6 +194,7 @@ Socket.prototype.createTransport = function (name) {
     ca: options.ca || this.ca,
     ciphers: options.ciphers || this.ciphers,
     rejectUnauthorized: options.rejectUnauthorized || this.rejectUnauthorized,
+    checkServerIdentity: options.checkServerIdentity || this.checkServerIdentity,
     perMessageDeflate: options.perMessageDeflate || this.perMessageDeflate,
     extraHeaders: options.extraHeaders || this.extraHeaders,
     forceNode: options.forceNode || this.forceNode,

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -39,6 +39,7 @@ function Transport (opts) {
   this.ca = opts.ca;
   this.ciphers = opts.ciphers;
   this.rejectUnauthorized = opts.rejectUnauthorized;
+  this.checkServerIdentity = opts.checkServerIdentity || null
   this.forceNode = opts.forceNode;
 
   // results of ReactNative environment detection

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -39,7 +39,7 @@ function Transport (opts) {
   this.ca = opts.ca;
   this.ciphers = opts.ciphers;
   this.rejectUnauthorized = opts.rejectUnauthorized;
-  this.checkServerIdentity = opts.checkServerIdentity || null
+  this.checkServerIdentity = opts.checkServerIdentity || null;
   this.forceNode = opts.forceNode;
 
   // results of ReactNative environment detection

--- a/lib/transports/websocket.js
+++ b/lib/transports/websocket.js
@@ -103,6 +103,7 @@ WS.prototype.doOpen = function () {
   opts.ca = this.ca;
   opts.ciphers = this.ciphers;
   opts.rejectUnauthorized = this.rejectUnauthorized;
+  opts.checkServerIdentity = this.checkServerIdentity;
   if (this.extraHeaders) {
     opts.headers = this.extraHeaders;
   }

--- a/lib/transports/websocket.js
+++ b/lib/transports/websocket.js
@@ -103,7 +103,9 @@ WS.prototype.doOpen = function () {
   opts.ca = this.ca;
   opts.ciphers = this.ciphers;
   opts.rejectUnauthorized = this.rejectUnauthorized;
-  opts.checkServerIdentity = this.checkServerIdentity;
+  if (this.checkServerIdentity) {
+    opts.checkServerIdentity = this.checkServerIdentity;
+  }
   if (this.extraHeaders) {
     opts.headers = this.extraHeaders;
   }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "engine.io-client",
   "description": "Client for the realtime Engine",
   "license": "MIT",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "main": "lib/index.js",
   "homepage": "https://github.com/socketio/engine.io-client",
   "contributors": [


### PR DESCRIPTION
*Note*: the `engine.io.js` file is the generated output of `make engine.io.js`, and should not be manually modified.

### The kind of change this PR does introduce

* [] a bug fix
* [x] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour

not able to set checkServerIdentity

### New behaviour

able to set checkServerIdentity

### Other information (e.g. related issues)

const io = require('socket.io-client');
const fs = require('fs')

const client = io('wss://localhost:3030', {
  transports: ['websocket'],
  secure: true,
  ca: fs.readFileSync('./server_cert.pem'),
  cert: fs.readFileSync('./user_cert.pem'),
  key: fs.readFileSync('./user_key.pem'),
  checkServerIdentity: () => { return null },
});

