### PR TITLE
feat: remove indexof

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -5,7 +5,6 @@
 var transports = require('./transports/index');
 var Emitter = require('component-emitter');
 var debug = require('debug')('engine.io-client:socket');
-var index = require('indexof');
 var parser = require('engine.io-parser');
 var parseuri = require('parseuri');
 var parseqs = require('parseqs');
@@ -742,7 +741,7 @@ Socket.prototype.onClose = function (reason, desc) {
 Socket.prototype.filterUpgrades = function (upgrades) {
   var filteredUpgrades = [];
   for (var i = 0, j = upgrades.length; i < j; i++) {
-    if (~index(this.transports, upgrades[i])) filteredUpgrades.push(upgrades[i]);
+    if (~this.transports.indexOf(upgrades[i])) filteredUpgrades.push(upgrades[i]);
   }
   return filteredUpgrades;
 };

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "debug": "~4.1.0",
     "engine.io-parser": "~2.2.0",
     "has-cors": "1.1.0",
-    "indexof": "0.0.1",
     "parseqs": "0.0.5",
     "parseuri": "0.0.5",
     "ws": "~6.1.0",


### PR DESCRIPTION
This is a polyfill for `indexOf()`, which is used without the polyfill literally everywhere else.

It lacks a license, or a maintainer, which angers our SCA tool.

### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other
