### PR TITLE
[fix] Use transpiled js for browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,16 +67,12 @@
   "scripts": {
     "test": "gulp test"
   },
-  "browser": {
-    "ws": false,
-    "xmlhttprequest-ssl": "./lib/xmlhttprequest.js"
-  },
+  "browser": "engine.io.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/socketio/engine.io-client.git"
   },
   "files": [
-    "index.js",
     "lib/",
     "engine.io.js"
   ]


### PR DESCRIPTION
*Note*: the `engine.io.js` file is the generated output of `make engine.io.js`, and should not be manually modified.

### The kind of change this PR does introduce

* [ ] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [x] other

### Current behaviour
Transpile to ES5 using bundler like webpack leaves ES6 code.

### New behaviour
Bundler will try to resolve using the transpiled ES5 file.

### Other information (e.g. related issues)
N/A

