### PR TITLE
Support `unref` method with option to `autoUnref`

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ Exposed as `eio` in the browser standalone build.
       - `onlyBinaryUpgrades` (`Boolean`): whether transport upgrades should be restricted to transports supporting binary data (`false`)
       - `forceNode` (`Boolean`): Uses NodeJS implementation for websockets - even if there is a native Browser-Websocket available, which is preferred by default over the NodeJS implementation. (This is useful when using hybrid platforms like nw.js or electron) (`false`, NodeJS only)
       - `localAddress` (`String`): the local IP address to connect to
+      - `autoUnref` (`Boolean`): whether the transport should be `unref`'d upon creation. This calls `unref` on the underyling timers and sockets so that the program is allowed to exit if they are the only timers/sockets in the event system.
     - **Polling-only options**
       - `requestTimeout` (`Number`): Timeout for xhr-polling requests in milliseconds (`0`)
     - **Websocket-only options**

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -70,6 +70,7 @@ class Socket extends Emitter {
         perMessageDeflate: {
           threshold: 1024
         },
+        autoUnref: false,
         transportOptions: {}
       },
       opts
@@ -201,6 +202,10 @@ class Socket extends Emitter {
       .on("close", function() {
         self.onClose("transport close");
       });
+
+    if (this.opts.autoUnref) {
+      transport.unref();
+    }
   }
 
   /**

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -201,11 +201,10 @@ class Socket extends Emitter {
       })
       .on("close", function() {
         self.onClose("transport close");
+      })
+      .on("open", function() {
+        if (this.opts.autoUnref) transport.unref();
       });
-
-    if (this.opts.autoUnref) {
-      transport.unref();
-    }
   }
 
   /**

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -427,6 +427,9 @@ class Socket extends Emitter {
     this.pingTimeoutTimer = setTimeout(() => {
       this.onClose("ping timeout");
     }, this.pingInterval + this.pingTimeout);
+    if (this.opts.autoUnref) {
+      this.pingTimeoutTimer.unref();
+    }
   }
 
   /**

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -48,7 +48,7 @@ class Transport extends Emitter {
 
   /**
    * Unrefs the transport
-   * 
+   *
    * @api public
    */
   unref() {

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -47,6 +47,16 @@ class Transport extends Emitter {
   }
 
   /**
+   * Unrefs the transport
+   * 
+   * @api public
+   */
+  unref() {
+    this.doUnref();
+    return this;
+  }
+
+  /**
    * Closes the transport.
    *
    * @api private

--- a/lib/transports/polling.js
+++ b/lib/transports/polling.js
@@ -26,7 +26,7 @@ class Polling extends Transport {
   /**
    * Ensure that event loop is not kept open only by this transport.
    * No-op for polling transports at present.
-   * 
+   *
    * @api private
    */
   doUnref() {

--- a/lib/transports/polling.js
+++ b/lib/transports/polling.js
@@ -24,6 +24,16 @@ class Polling extends Transport {
   }
 
   /**
+   * Ensure that event loop is not kept open only by this transport.
+   * No-op for polling transports at present.
+   * 
+   * @api private
+   */
+  doUnref() {
+    return;
+  }
+
+  /**
    * Pauses polling.
    *
    * @param {Function} callback upon buffers are flushed and transport is paused

--- a/lib/transports/websocket.js
+++ b/lib/transports/websocket.js
@@ -97,7 +97,7 @@ class WS extends Transport {
 
   /**
    * Unrefs socket.
-   * 
+   *
    * @api private
    */
   doUnref() {

--- a/lib/transports/websocket.js
+++ b/lib/transports/websocket.js
@@ -102,7 +102,6 @@ class WS extends Transport {
    */
   doUnref() {
     this.ws._socket.unref();
-    this.socket.pingTimeoutTimer.unref();
   }
 
   /**

--- a/lib/transports/websocket.js
+++ b/lib/transports/websocket.js
@@ -96,6 +96,16 @@ class WS extends Transport {
   }
 
   /**
+   * Unrefs socket.
+   * 
+   * @api private
+   */
+  doUnref() {
+    this.ws._socket.unref();
+    this.socket.pingTimeoutTimer.unref();
+  }
+
+  /**
    * Adds event listeners to the socket
    *
    * @api private


### PR DESCRIPTION
### The kind of change this PR does introduce

* [ ] a bug fix
* [x] a new feature
* [x] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour

Users must call `close` on any stray transports if they want their program to be able to exit.

### New behaviour

Users may either call `unref` directly or pass a new option `autoUnref: true` to allow a program to exit which has only an engine.io transport on the event loop.

### Other information (e.g. related issues)

`unref` is a common feature for APIs that can prevent the event loop from exiting. See also:
* https://node.readthedocs.io/en/latest/api/timers/#unref
* https://node.readthedocs.io/en/latest/api/net/#class-netsocket
* https://node.readthedocs.io/en/latest/api/net/#class-netserver

