### PR TITLE
fix: replace default nulls in SSL options with undefineds

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -86,12 +86,12 @@ function Socket (uri, opts) {
   }
 
   // SSL options for Node.js client
-  this.pfx = opts.pfx || null;
-  this.key = opts.key || null;
-  this.passphrase = opts.passphrase || null;
-  this.cert = opts.cert || null;
-  this.ca = opts.ca || null;
-  this.ciphers = opts.ciphers || null;
+  this.pfx = opts.pfx || undefined;
+  this.key = opts.key || undefined;
+  this.passphrase = opts.passphrase || undefined;
+  this.cert = opts.cert || undefined;
+  this.ca = opts.ca || undefined;
+  this.ciphers = opts.ciphers || undefined;
   this.rejectUnauthorized = opts.rejectUnauthorized === undefined ? true : opts.rejectUnauthorized;
   this.forceNode = !!opts.forceNode;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "engine.io-client",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "engine.io-client",
   "description": "Client for the realtime Engine",
   "license": "MIT",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "main": "lib/index.js",
   "homepage": "https://github.com/socketio/engine.io-client",
   "contributors": [


### PR DESCRIPTION
See socketio/engine.io-client#654.

*Note*: the `engine.io.js` file is the generated output of `make engine.io.js`, and should not be manually modified.

### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour
Fails on node.js 15 as described in https://github.com/socketio/engine.io-client/issues/654.

### New behaviour
Works on node.js 15

### Other information (e.g. related issues)
I was only able to get the tests to pass by installing node.js 10.  Newer versions seem to break a dependency of a dependency of (...) gulp, and I didn't want to go down that rabbit hole in this PR.  The example code given in #654 now works on node.js v15.

I also bumped the patch version to 3.5.1, but please let me know if you'd prefer to drop it back to 3.5.0 and let you do the version bump as part of your publishing process.

