### PR TITLE
fix: For TikTok miniprograme env

### DIFF
--- a/lib/globalThis.browser.js
+++ b/lib/globalThis.browser.js
@@ -3,6 +3,8 @@ module.exports = (() => {
     return self;
   } else if (typeof window !== "undefined") {
     return window;
+  } else if (typeof global !== "undefined") {
+    return global;
   } else {
     return Function("return this")();
   }


### PR DESCRIPTION
*Note*: the `engine.io.js` file is the generated output of `make engine.io.js`, and should not be manually modified.

### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour
Becase TikTok use custom browser env in it's miniprograme, So:
1. The Global object "WebSocket" not exists 
2. The var "window" can't be set/get (the var "global" can be set/get) in this env

For using socket.io in this env, Using a polyfill is a good choice, but the polyfill can't set the val "window" for engine.io-client(only can set the val "global")

### New behaviour
The polyfill can work with engine.io, and we can use socket.io in TikTok miniprograme env 

### Other information (e.g. related issues)


