### PR TITLE
Detect which websocket to import in Code

### DIFF
--- a/lib/transports/websocket.js
+++ b/lib/transports/websocket.js
@@ -3,11 +3,19 @@ const parser = require("engine.io-parser");
 const parseqs = require("parseqs");
 const yeast = require("yeast");
 const { pick } = require("../util");
+
+const isBrowser =
+  typeof navigator !== "undefined" && typeof process === "undefined";
+
+const websocketConstructorName = isBrowser
+  ? "./websocket-constructor.browser"
+  : "./websocket-constructor";
+
 const {
   WebSocket,
   usingBrowserWebSocket,
   defaultBinaryType
-} = require("./websocket-constructor");
+} = require(websocketConstructorName);
 
 const debug = require("debug")("engine.io-client:websocket");
 


### PR DESCRIPTION
*Note*: the `engine.io.js` file is the generated output of `make engine.io.js`, and should not be manually modified.

### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour

Currently, the engine.io will determine which `websocket constructor` in import in the building process(Correct me if I am wrong).
In some cases, we want to use it from npm and deploy it to the browser platform. This may introduce some unexpected behaviour, like mistakenly importing the non-browser `websocket constructor` into the browser env.

### New behaviour

Determine which `constructor` with given runtime.

### Other information (e.g. related issues)


