### PR TITLE
Fix websocket timer throttle blocking writes

### DIFF
--- a/lib/transports/websocket.js
+++ b/lib/transports/websocket.js
@@ -161,10 +161,10 @@ class WS extends Transport {
         if (lastPacket) {
           // fake drain
           // defer to next tick to allow Socket to clear writeBuffer
-          setTimeout(() => {
+          Promise.resolve().then(() => {
             this.writable = true;
             this.emit("drain");
-          }, 0);
+          });
         }
       });
     }


### PR DESCRIPTION

*Note*: the `engine.io.js` file is the generated output of `make engine.io.js`, and should not be manually modified.

### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour

An immediate setTimeout is used to unblock the WebSocket write. Unfortunately, this setTimeout can be throttled by browsers when the tab is backgrounded. This can lead to missed pong responses to server pings which leads to disconnects.

### New behaviour

Move the unblocking code block into a then handler of an immediate Promise.resolve. The then handler does not suffer from Timer throttling and will ensure the code gets executed asynchronously without unintended delay.

### Other information (e.g. related issues)

https://github.com/socketio/engine.io-client/issues/649#issuecomment-822906646


