### PR TITLE
Make postcompile.sh script work on macOS

### DIFF
--- a/postcompile.sh
+++ b/postcompile.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cp ./support/package.cjs.json ./build/cjs/package.json
 cp ./support/package.esm.json ./build/esm/package.json

--- a/postcompile.sh
+++ b/postcompile.sh
@@ -5,4 +5,8 @@ cp ./support/package.esm.json ./build/esm/package.json
 
 cp -r ./build/esm/ ./build/esm-debug/
 
-sed -i '/debug(/d' ./build/esm/*.js ./build/esm/**/*.js
+if [ "${OSTYPE:0:6}" = darwin ]; then
+  sed -i '' -e '/debug(/d' ./build/esm/*.js ./build/esm/**/*.js
+else
+  sed -i -e '/debug(/d' ./build/esm/*.js ./build/esm/**/*.js
+fi


### PR DESCRIPTION
*Note*: the `engine.io.js` file is the generated output of `make engine.io.js`, and should not be manually modified.

### The kind of change this PR does introduce

* [ ] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [x] other

### Current behaviour

The `npm run compile` command does not work on macOS due to an invalid usage of `sed` in the `postcompile.sh` script

### New behaviour

`npm run compile` runs without errors on macOS.

### Other information (e.g. related issues)

First commit

```
build: use env in shebang

Use the `bash` executable that appears first in user's `PATH`.
```

Second commit

```
build: make postcompile.sh script work on macOS
    
On macOS the script is currently interpreted as the value of the `-i`
option. Use an empty extension for the `-i` option and the `-e` option
to specify the script.
```