### PR TITLE
Add main minified dist file as exportable asset

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
   "module": "./build/esm/index.js",
   "exports": {
     "./package.json": "./package.json",
+    "./dist/engine.io.esm.min.js": "./dist/engine.io.esm.min.js",
+    "./dist/engine.io.js": "./dist/engine.io.js",
     "./dist/engine.io.min.js": "./dist/engine.io.min.js",
     ".": {
       "import": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "module": "./build/esm/index.js",
   "exports": {
     "./package.json": "./package.json",
+    "./dist/engine.io.min.js": "./dist/engine.io.min.js",
     ".": {
       "import": {
         "node": "./build/esm-debug/index.js",


### PR DESCRIPTION
*Note*: the `engine.io.js` file is the generated output of `make engine.io.js`, and should not be manually modified.

### The kind of change this PR does introduce

* [ ] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [x] other

### Current behaviour

With the recent introduction of the exports block to package.json, modern node limits the files which can be imported from the module. Previously it was possible to import the main dist file directly. Now with the introduction of the exports block one receives an error trying to import the `engine.io.min.js` file:

`[ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './dist/engine.io.min.js' is not defined by "exports"`

Proposal to add at least the minified file to be exportable.

### New behaviour

Does not introduce new behaviour, restores old one where it was possible to import any file from the package as there was no exports block on the package level defined - thus node allowed to export any file.

### Other information (e.g. related issues)

The complete file list could be expanded to all the .js files listed in `./dist` in case any other file is consumed directly.

