### PR TITLE
fix: workaround undefined global this

### DIFF
--- a/lib/transports/polling.ts
+++ b/lib/transports/polling.ts
@@ -7,7 +7,10 @@ import XMLHttpRequest from "./xmlhttprequest.js";
 import { Emitter } from "@socket.io/component-emitter";
 import { SocketOptions } from "../socket.js";
 import { installTimerFunctions, pick } from "../util.js";
-import globalThis from "../globalThis.js";
+import * as globalThisModule from "../globalThis.js";
+const globalThis =
+  globalThisModule.default ||
+  ((globalThisModule as any) as typeof globalThisModule.default);
 
 const debug = debugModule("engine.io-client:polling"); // debug()
 

--- a/lib/transports/websocket-constructor.browser.ts
+++ b/lib/transports/websocket-constructor.browser.ts
@@ -1,4 +1,7 @@
-import globalThis from "../globalThis.js";
+import * as globalThisModule from "../globalThis.js";
+const globalThis =
+  globalThisModule.default ||
+  ((globalThisModule as any) as typeof globalThisModule.default);
 
 export const nextTick = (() => {
   const isPromiseAvailable =

--- a/lib/transports/xmlhttprequest.browser.ts
+++ b/lib/transports/xmlhttprequest.browser.ts
@@ -1,7 +1,10 @@
 // browser shim for xmlhttprequest module
 
 import { hasCORS } from "../contrib/has-cors.js";
-import globalThis from "../globalThis.js";
+import * as globalThisModule from "../globalThis.js";
+const globalThis =
+  globalThisModule.default ||
+  ((globalThisModule as any) as typeof globalThisModule.default);
 
 export default function(opts) {
   const xdomain = opts.xdomain;

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -1,4 +1,7 @@
-import globalThis from "./globalThis.js";
+import * as globalThisModule from "./globalThis.js";
+const globalThis =
+  globalThisModule.default ||
+  ((globalThisModule as any) as typeof globalThisModule.default);
 
 export function pick(obj, ...attr) {
   return attr.reduce((acc, k) => {

--- a/lib/xmlhttprequest.ts
+++ b/lib/xmlhttprequest.ts
@@ -1,7 +1,10 @@
 // browser shim for xmlhttprequest module
 
 import { hasCORS } from "./contrib/has-cors.js";
-import globalThis from "./globalThis.js";
+import * as globalThisModule from "./globalThis.js";
+const globalThis =
+  globalThisModule.default ||
+  ((globalThisModule as any) as typeof globalThisModule.default);
 
 export default function(opts) {
   const xdomain = opts.xdomain;


### PR DESCRIPTION
*Note*: the `engine.io.js` file is the generated output of `make engine.io.js`, and should not be manually modified.

### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour

Default export of `globalThis` seems to have a problem
in the "browser" field when the library is loaded asynchronously.

We are using engine.io-client via socket.io-client.
We recently upgraded sockete.io-client from `v3.1.3` to `v4.4.1`.

And we started seeing the following error:
<img width="595" alt="Screen Shot 2022-04-22 at 11 25 05" src="https://user-images.githubusercontent.com/2261067/164584511-96870a7e-6c71-4941-888a-841bfde200b4.png">

`globalThis` is undefined here:
https://github.com/socketio/engine.io-client/blob/3c40aa91b05a13d7ebfc76ceedb8c13fd4e20f05/lib/transports/polling-xhr.ts#L315

We've confirmed that the issue started from socket.io-client `v4.3.0`,
which is the version where both socket.io-client and engine.io-client
migrated their builds from webpack to rollup.

So we are suspecting it's the compatibility issue of mixing webpack and rollup.

### New behaviour

Avoid using default import resolves the issue.

### Other information (e.g. related issues)

this might be related:
https://github.com/socketio/engine.io-client/commit/49719142f65e23efa65fca4f66765ded5d955972