### PR TITLE
refactor: replace deprecated `String.prototype.substr()`

### DIFF
--- a/lib/contrib/parseuri.ts
+++ b/lib/contrib/parseuri.ts
@@ -45,10 +45,10 @@ function pathNames(obj, path) {
     const regx = /\/{2,9}/g,
         names = path.replace(regx, "/").split("/");
 
-    if (path.substr(0, 1) == '/' || path.length === 0) {
+    if (path.slice(0, 1) == '/' || path.length === 0) {
         names.splice(0, 1);
     }
-    if (path.substr(path.length - 1, 1) == '/') {
+    if (path.slice(-1) == '/') {
         names.splice(names.length - 1, 1);
     }
 


### PR DESCRIPTION
*Note*: the `engine.io.js` file is the generated output of `make engine.io.js`, and should not be manually modified.

### The kind of change this PR does introduce

* [ ] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [x] other

### Current behaviour
Deprecated [`String.prototype.substr()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is used.

### New behaviour
[`String.prototype.slice()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) is used instead.

### Other information (e.g. related issues)
N.A.