### PR TITLE
Adding an option to avoid the added trailing slash to the path

### DIFF
--- a/test/engine.io-client.js
+++ b/test/engine.io-client.js
@@ -58,6 +58,12 @@ describe("engine.io-client", () => {
     expect(client.port).to.be("8080");
   });
 
+  it("should properly handle the trailingSlash option", () => {
+    const client = new Socket({ host: "localhost", trailingSlash: false });
+    expect(client.hostname).to.be("localhost");
+    expect(client.opts.path).to.be("/engine.io");
+  });
+
   it("should properly parse an IPv6 uri without port", () => {
     const client = new Socket("http://[::1]");
     expect(client.hostname).to.be("::1");


### PR DESCRIPTION
Signed-off-by: iifawzi <iifawzie@gmail.com>

Hi, this PR is adding an option to avoid the added path trailing slash in the connection
Resolving https://github.com/socketio/socket.io-client/issues/1550.

An example of a use case for this is the Microsoft bot framework stream URL:
[Reconnect to a conversation in Direct Line API 3.0](https://learn.microsoft.com/en-us/azure/bot-service/rest-api/bot-framework-rest-direct-line-3-0-reconnect-to-conversation?view=azure-bot-service-4.0#response)

```JS
io(`wss://directline.botframework.com/v3/directline/conversations/convId/stream?t=tokenId`)
```

I needed to use the native WebSocket since the `engine.io-client` is always adding a trailing slash after `stream` which broke the URI and hence the connection. 

Having this as an optional option would solve such use cases. 
* [ ] a bug fix
* [x] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour
a trailing slash is always added to the `path`. 
### New behaviour
a trailing slash is still added to the `path`, but can be avoided by setting the `trailingSlash` option to false. 


