### PR TITLE
fix: timeout bound conetext is not origin

### DIFF
--- a/lib/util.ts
+++ b/lib/util.ts
@@ -10,16 +10,16 @@ export function pick(obj, ...attr) {
 }
 
 // Keep a reference to the real timeout functions so they can be used when overridden
-const NATIVE_SET_TIMEOUT = setTimeout;
-const NATIVE_CLEAR_TIMEOUT = clearTimeout;
+const NATIVE_SET_TIMEOUT = globalThis.setTimeout;
+const NATIVE_CLEAR_TIMEOUT = globalThis.clearTimeout;
 
 export function installTimerFunctions(obj, opts) {
   if (opts.useNativeTimers) {
     obj.setTimeoutFn = NATIVE_SET_TIMEOUT.bind(globalThis);
     obj.clearTimeoutFn = NATIVE_CLEAR_TIMEOUT.bind(globalThis);
   } else {
-    obj.setTimeoutFn = setTimeout.bind(globalThis);
-    obj.clearTimeoutFn = clearTimeout.bind(globalThis);
+    obj.setTimeoutFn = globalThis.setTimeout.bind(globalThis);
+    obj.clearTimeoutFn = globalThis.clearTimeout.bind(globalThis);
   }
 }
 


### PR DESCRIPTION
*Note*: the `engine.io.js` file is the generated output of `make engine.io.js`, and should not be manually modified.

### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour
none.

### New behaviour
none.

### Other information (e.g. related issues)

Sometimes (like me), I get an "Illegal invocation" error in my project and I try to fix it. You can see the link for details.

I think the code of this settimeout is not rigorous enough, and I hope to make the code stronger.

https://mtsknn.fi/blog/illegal-invocations-in-js/
