### PR TITLE
fix: pingTimeout is not reset while receiving messages

### DIFF
--- a/lib/socket.ts
+++ b/lib/socket.ts
@@ -683,6 +683,7 @@ export class Socket extends Emitter<
           break;
 
         case "message":
+          this.resetPingTimeout();
           this.emitReserved("data", packet.data);
           this.emitReserved("message", packet.data);
           break;


### PR DESCRIPTION
*Note*: the `engine.io.js` file is the generated output of `make engine.io.js`, and should not be manually modified.

### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour

In the case where a client is has a slow connection it is possible for the pingTimeout to trigger while messages
are still being transferred from the server. My understanding is that this is because the ping messages are sent "in-band" with all the other messages which means they can essentially become blocking in the queue behind multiple
other messages.

### New behaviour

This PR makes the assumption that if the client is receiving messages, the link must be ok, so will reset the ping
timeout for any message that arrives at the client. This means that ping timeouts will not occur as long
as a single message can be transferred within the configured ping timeout + ping interval.

It appears the server side implementation of engine.io also uses a similar mechanism.
https://github.com/socketio/engine.io/blob/main/lib/socket.ts#L147

### Other information (e.g. related issues)

