### PR TITLE
Fix type of SocketOptions.agent property

### DIFF
--- a/lib/socket.ts
+++ b/lib/socket.ts
@@ -8,6 +8,8 @@ import { protocol } from "engine.io-parser";
 import type { Packet, BinaryType, PacketType, RawData } from "engine.io-parser";
 import { CloseDetails, Transport } from "./transport.js";
 import { defaultBinaryType } from "./transports/websocket-constructor.js";
+import {Agent as HttpAgent} from 'http';
+import {Agent as HttpsAgent} from 'https';
 
 const debug = debugModule("engine.io-client:socket"); // debug()
 
@@ -40,7 +42,7 @@ export interface SocketOptions {
   /**
    * `http.Agent` to use, defaults to `false` (NodeJS only)
    */
-  agent: string | boolean;
+  agent: string | boolean | HttpAgent | HttpsAgent;
 
   /**
    * Whether the client should try to upgrade the transport from


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour

The current type definition of the `agent` property of `SocketOptions` makes it difficult to pass in a custom http agent because it only accepts a `string` or a `boolean`:

```
  /**
   * `http.Agent` to use, defaults to `false` (NodeJS only)
   */
  agent: string | boolean;
```

In order to pass in a custom agent you need to do something like:
```
const options = {
  agent: myAgent as unknown as string
};
```

### New behaviour

The type of the `agent` property now allows includes `http.Agent` and `https.Agent` .

I think the correct type should actually be `http.Agent | https.Agent | false`, but I kept the original `string | boolean` for backwards compatibility.

### Other information (e.g. related issues)


