### PR TITLE
Export TransportError

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -3,7 +3,7 @@ import { Socket } from "./socket.js";
 export { Socket };
 export { SocketOptions } from "./socket.js";
 export const protocol = Socket.protocol;
-export { Transport } from "./transport.js";
+export { Transport, TransportError } from "./transport.js";
 export { transports } from "./transports/index.js";
 export { installTimerFunctions } from "./util.js";
 export { parse } from "./contrib/parseuri.js";

--- a/lib/transport.ts
+++ b/lib/transport.ts
@@ -8,7 +8,7 @@ import { encode } from "./contrib/parseqs.js";
 
 const debug = debugModule("engine.io-client:transport"); // debug()
 
-class TransportError extends Error {
+export class TransportError extends Error {
   public readonly type = "TransportError";
 
   constructor(


### PR DESCRIPTION
### The kind of change this PR does introduce

* [ ] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [x ] other

### Current behaviour

Currently `TransportError` is not exported, so if you want to check if an error is a `TransportError` in TypeScript with `eslint` you need to do something like this:

```
// eslint-disable-next-line @typescript-eslint/no-explicit-any
if ((error as any).type === 'TransportError') {
  ...
}
```

It's kind of a minor inconvenience, but many `eslint` configs prohibit the use of `any`, so it results in some extra boilerplate every time you need to do this check.

### New behaviour

By exporting `TransportError` we will be able to import the type and perform the check like this:

```
if ((error as TransportError).type === 'TransportError') {
  ...
}
```

It should also make it possible to use `instanceof` instead: `error instanceof TransportError`.

### Other information (e.g. related issues)

If this suggestion is accepted I'll make a follow-up PR to https://github.com/socketio/socket.io-client to export the type from there as well.

